### PR TITLE
Avoid copy in count / logical nulls

### DIFF
--- a/datafusion/physical-expr/src/aggregate/count.rs
+++ b/datafusion/physical-expr/src/aggregate/count.rs
@@ -202,6 +202,7 @@ fn logical_nulls(array: &dyn Array) -> Option<Cow<'_, NullBuffer>> {
     match array.data_type() {
         // These types have computed null buffers, so need a call to logical nulls
         // TODO remove when upstream is released
+        // https://github.com/apache/arrow-rs/issues/5208
         DataType::Null | DataType::Dictionary(_, _) => {
             array.logical_nulls().map(Cow::Owned)
         }


### PR DESCRIPTION
This is a proposed improvement of  https://github.com/apache/arrow-datafusion/pull/8511  to avoid copying Null Buffers in the count aggregator. 

Note this targets https://github.com/apache/arrow-datafusion/pull/8511

I will also file a proposal to upstream this change into arrow-rs

cc @joroKr21 and @Dandandan 