### PR TITLE
Check list size before concat in ScalarValue (#10329)

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -2208,7 +2208,11 @@ impl ScalarValue {
 
     fn list_to_array_of_size(arr: &dyn Array, size: usize) -> Result<ArrayRef> {
         let arrays = std::iter::repeat(arr).take(size).collect::<Vec<_>>();
-        Ok(arrow::compute::concat(arrays.as_slice())?)
+        let ret = match !arrays.is_empty() {
+            true => arrow::compute::concat(arrays.as_slice())?,
+            false => arr.slice(0, 0),
+        };
+        Ok(ret)
     }
 
     /// Retrieve ScalarValue for each row in `array`
@@ -3565,6 +3569,12 @@ mod tests {
             &expected_arr,
             as_fixed_size_list_array(actual_arr.as_ref()).unwrap()
         );
+
+        let empty_array = sv
+            .to_array_of_size(0)
+            .expect("Failed to convert to empty array");
+
+        assert_eq!(empty_array.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
* Add check in list_to_array_of_size to see if any data will be returned. If not, do not attempt to call concat on empty arrays.

* Formatting

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->