### PR TITLE
Fix nullability of output

### DIFF
--- a/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
+++ b/datafusion/physical-expr/src/aggregate/approx_percentile_cont.rs
@@ -195,7 +195,8 @@ impl AggregateExpr for ApproxPercentileCont {
     }
 
     fn field(&self) -> Result<Field> {
-        Ok(Field::new(&self.name, self.input_data_type.clone(), false))
+        // Answer might be NULL if inputs are all NULL or having empty input
+        Ok(Field::new(&self.name, self.input_data_type.clone(), true))
     }
 
     #[allow(rustdoc::private_intra_doc_links)]

--- a/datafusion/physical-expr/src/aggregate/build_in.rs
+++ b/datafusion/physical-expr/src/aggregate/build_in.rs
@@ -499,7 +499,7 @@ mod tests {
             assert!(result_agg_phy_exprs.as_any().is::<ApproxPercentileCont>());
             assert_eq!("c1", result_agg_phy_exprs.name());
             assert_eq!(
-                Field::new("c1", data_type.clone(), false),
+                Field::new("c1", data_type.clone(), true),
                 result_agg_phy_exprs.field().unwrap()
             );
         }

--- a/datafusion/sqllogictest/test_files/aggregate.slt
+++ b/datafusion/sqllogictest/test_files/aggregate.slt
@@ -1224,6 +1224,12 @@ SELECT APPROX_PERCENTILE_CONT(v, 0.5) FROM (VALUES (1), (2), (3), (NULL), (NULL)
 ----
 2
 
+# percentile_cont_with_nulls_only
+query I
+SELECT APPROX_PERCENTILE_CONT(v, 0.5) FROM (VALUES (CAST(NULL as INT))) as t (v);
+----
+NULL
+
 # csv_query_cube_avg
 query TIR
 SELECT c1, c2, AVG(c3) FROM aggregate_test_100 GROUP BY CUBE (c1, c2) ORDER BY c1, c2


### PR DESCRIPTION
# Which issue does this PR close?

There was a discrepancy between upstream DataFusion and v39 wrt. nullability of aggregate functions.
This change fixes `ApproxPercentileCont` to be nullable. It works in upstream DataFusion, so doesn't need to be upstreamed.

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->