### PR TITLE
VTX-7456 Add support for temporal data types in interval arithmetics

### DIFF
--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -1205,6 +1205,17 @@ impl ScalarValue {
         }
     }
 
+    /// Returns negation for a boolean scalar value
+    pub fn boolean_negate(&self) -> Result<Self> {
+        match self {
+            ScalarValue::Boolean(None) => Ok(self.clone()),
+            ScalarValue::Boolean(Some(value)) => Ok(ScalarValue::Boolean(Some(!value))),
+            value => _internal_err!(
+                    "Can not run boolean negative on scalar value {value:?}"
+                ),
+        }
+    }
+
     /// Wrapping addition of `ScalarValue`
     ///
     /// NB: operating on `ScalarValue` directly is not efficient, performance sensitive code

--- a/datafusion/common/src/scalar/mod.rs
+++ b/datafusion/common/src/scalar/mod.rs
@@ -1210,9 +1210,9 @@ impl ScalarValue {
         match self {
             ScalarValue::Boolean(None) => Ok(self.clone()),
             ScalarValue::Boolean(Some(value)) => Ok(ScalarValue::Boolean(Some(!value))),
-            value => _internal_err!(
-                    "Can not run boolean negative on scalar value {value:?}"
-                ),
+            value => {
+                _internal_err!("Can not run boolean negative on scalar value {value:?}")
+            }
         }
     }
 

--- a/datafusion/core/src/physical_optimizer/join_selection.rs
+++ b/datafusion/core/src/physical_optimizer/join_selection.rs
@@ -1578,7 +1578,6 @@ mod util_tests {
     use arrow_schema::{DataType, Field, Schema};
     use datafusion_expr::Operator;
     use datafusion_physical_expr::expressions::{BinaryExpr, Column, NegativeExpr};
-    use datafusion_physical_expr::intervals::utils::check_support;
     use datafusion_physical_expr::PhysicalExpr;
 
     #[test]
@@ -1592,21 +1591,24 @@ mod util_tests {
             Operator::Plus,
             Arc::new(Column::new("a", 0)),
         )) as Arc<dyn PhysicalExpr>;
-        assert!(check_support(&supported_expr, &schema));
+        assert!(supported_expr.supports_bounds_evaluation(&schema));
+
         let supported_expr_2 = Arc::new(Column::new("a", 0)) as Arc<dyn PhysicalExpr>;
-        assert!(check_support(&supported_expr_2, &schema));
+        assert!(supported_expr_2.supports_bounds_evaluation(&schema));
+
         let unsupported_expr = Arc::new(BinaryExpr::new(
             Arc::new(Column::new("a", 0)),
             Operator::Or,
             Arc::new(Column::new("a", 0)),
         )) as Arc<dyn PhysicalExpr>;
-        assert!(!check_support(&unsupported_expr, &schema));
+        assert!(!unsupported_expr.supports_bounds_evaluation(&schema));
+
         let unsupported_expr_2 = Arc::new(BinaryExpr::new(
             Arc::new(Column::new("a", 0)),
             Operator::Or,
             Arc::new(NegativeExpr::new(Arc::new(Column::new("a", 0)))),
         )) as Arc<dyn PhysicalExpr>;
-        assert!(!check_support(&unsupported_expr_2, &schema));
+        assert!(!unsupported_expr_2.supports_bounds_evaluation(&schema));
     }
 }
 

--- a/datafusion/core/src/physical_optimizer/pipeline_checker.rs
+++ b/datafusion/core/src/physical_optimizer/pipeline_checker.rs
@@ -29,7 +29,7 @@ use crate::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_common::config::OptimizerOptions;
 use datafusion_common::plan_err;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion_physical_expr::intervals::utils::{check_support, is_datatype_supported};
+use datafusion_physical_expr::intervals::utils::{is_datatype_supported};
 use datafusion_physical_plan::joins::SymmetricHashJoinExec;
 
 /// The PipelineChecker rule rejects non-runnable query plans that use
@@ -96,7 +96,7 @@ pub fn check_finiteness_requirements(
 /// [`Operator`]: datafusion_expr::Operator
 fn is_prunable(join: &SymmetricHashJoinExec) -> bool {
     join.filter().map_or(false, |filter| {
-        check_support(filter.expression(), &join.schema())
+        filter.expression().supports_bounds_evaluation(&join.schema())
             && filter
                 .schema()
                 .fields()

--- a/datafusion/core/src/physical_optimizer/pipeline_checker.rs
+++ b/datafusion/core/src/physical_optimizer/pipeline_checker.rs
@@ -29,7 +29,7 @@ use crate::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_common::config::OptimizerOptions;
 use datafusion_common::plan_err;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion_physical_expr::intervals::utils::is_datatype_supported;
+use datafusion_physical_expr_common::utils::is_supported_datatype_for_bounds_eval;
 use datafusion_physical_plan::joins::SymmetricHashJoinExec;
 
 /// The PipelineChecker rule rejects non-runnable query plans that use
@@ -103,7 +103,7 @@ fn is_prunable(join: &SymmetricHashJoinExec) -> bool {
                 .schema()
                 .fields()
                 .iter()
-                .all(|f| is_datatype_supported(f.data_type()))
+                .all(|f| is_supported_datatype_for_bounds_eval(f.data_type()))
     })
 }
 

--- a/datafusion/core/src/physical_optimizer/pipeline_checker.rs
+++ b/datafusion/core/src/physical_optimizer/pipeline_checker.rs
@@ -29,7 +29,7 @@ use crate::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_common::config::OptimizerOptions;
 use datafusion_common::plan_err;
 use datafusion_common::tree_node::{Transformed, TransformedResult, TreeNode};
-use datafusion_physical_expr::intervals::utils::{is_datatype_supported};
+use datafusion_physical_expr::intervals::utils::is_datatype_supported;
 use datafusion_physical_plan::joins::SymmetricHashJoinExec;
 
 /// The PipelineChecker rule rejects non-runnable query plans that use
@@ -96,7 +96,9 @@ pub fn check_finiteness_requirements(
 /// [`Operator`]: datafusion_expr::Operator
 fn is_prunable(join: &SymmetricHashJoinExec) -> bool {
     join.filter().map_or(false, |filter| {
-        filter.expression().supports_bounds_evaluation(&join.schema())
+        filter
+            .expression()
+            .supports_bounds_evaluation(&join.schema())
             && filter
                 .schema()
                 .fields()

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -288,23 +288,11 @@ impl Interval {
             // Standardize floating-point endpoints:
             DataType::Float32 => handle_float_intervals!(Float32, f32, lower, upper),
             DataType::Float64 => handle_float_intervals!(Float64, f64, lower, upper),
-            // Unsigned null values for lower bounds are set to zero:
-            DataType::UInt8 if lower.is_null() => Self {
-                lower: ScalarValue::UInt8(Some(0)),
-                upper,
-            },
-            DataType::UInt16 if lower.is_null() => Self {
-                lower: ScalarValue::UInt16(Some(0)),
-                upper,
-            },
-            DataType::UInt32 if lower.is_null() => Self {
-                lower: ScalarValue::UInt32(Some(0)),
-                upper,
-            },
-            DataType::UInt64 if lower.is_null() => Self {
-                lower: ScalarValue::UInt64(Some(0)),
-                upper,
-            },
+            // Lower bounds of unsigned integer null values are set to zero:
+            // DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 if lower.is_null() => Self {
+            //     lower: ScalarValue::new_zero(&lower.data_type()).unwrap(),
+            //     upper,
+            // },
             // Other data types do not require standardization:
             _ => Self { lower, upper },
         }
@@ -355,8 +343,8 @@ impl Interval {
 
         // There must be no way to create an interval whose endpoints have
         // different types.
-        assert!(
-            lower_type == upper_type,
+        assert_eq!(
+            lower_type, upper_type,
             "Interval bounds have different types: {lower_type} != {upper_type}"
         );
         lower_type
@@ -372,6 +360,10 @@ impl Interval {
             cast_scalar_value(&self.lower, data_type, cast_options)?,
             cast_scalar_value(&self.upper, data_type, cast_options)?,
         )
+    }
+
+    pub fn is_null(&self) -> bool {
+        self.lower.is_null() && self.upper.is_null()
     }
 
     pub const CERTAINLY_FALSE: Self = Self {
@@ -564,6 +556,36 @@ impl Interval {
         }
     }
 
+    pub fn union<T: Borrow<Self>>(&self, other: T) -> Result<Option<Self>> {
+        let rhs = other.borrow();
+        if self.data_type().ne(&rhs.data_type()) {
+            return internal_err!(
+                "Only intervals with the same data type are intersectable, lhs:{}, rhs:{}",
+                self.data_type(),
+                rhs.data_type()
+            );
+        };
+
+        // If it is evident that the result is an empty interval, short-circuit
+        // and directly return `None`.
+        if (!(self.lower.is_null() || rhs.upper.is_null()) && self.lower > rhs.upper)
+            || (!(self.upper.is_null() || rhs.lower.is_null()) && self.upper < rhs.lower)
+        {
+            return Ok(None);
+        }
+
+        let lower = min_of_bounds(&self.lower, &rhs.lower);
+        let upper = max_of_bounds(&self.upper, &rhs.upper);
+
+        // New lower and upper bounds must always construct a valid interval.
+        assert!(
+            lower.is_null() || upper.is_null() || (lower <= upper),
+            "The intersection of two intervals can not be an invalid interval"
+        );
+
+        Ok(Some(Self { lower, upper }))
+    }
+
     /// Compute the intersection of this interval with the given interval.
     /// If the intersection is empty, return `None`.
     ///
@@ -593,7 +615,7 @@ impl Interval {
 
         // New lower and upper bounds must always construct a valid interval.
         assert!(
-            (lower.is_null() || upper.is_null() || (lower <= upper)),
+            lower.is_null() || upper.is_null() || (lower <= upper),
             "The intersection of two intervals can not be an invalid interval"
         );
 
@@ -846,9 +868,9 @@ pub fn apply_operator(op: &Operator, lhs: &Interval, rhs: &Interval) -> Result<I
         Operator::Multiply => lhs.mul(rhs),
         Operator::Divide => lhs.div(rhs),
         Operator::IsDistinctFrom | Operator::IsNotDistinctFrom => {
-            let nullable_interval = NullableInterval::from(lhs)
-                .apply_operator(op, &NullableInterval::from(rhs));
-            nullable_interval.and_then(|x| {
+            NullableInterval::from(lhs)
+                .apply_operator(op, &NullableInterval::from(rhs))
+                .and_then(|x| {
                 x.values().cloned().ok_or(DataFusionError::Internal(
                     "Unexpected null value interval".to_string(),
                 ))
@@ -1185,17 +1207,17 @@ pub fn satisfy_greater(
     }
 
     if !left.upper.is_null() && left.upper <= right.lower {
-        if !strict && left.upper == right.lower {
+        return if !strict && left.upper == right.lower {
             // Singleton intervals:
-            return Ok(Some((
+            Ok(Some((
                 Interval::new(left.upper.clone(), left.upper.clone()),
                 Interval::new(left.upper.clone(), left.upper.clone()),
-            )));
+            )))
         } else {
             // Left-hand side:  <--======----0------------>
             // Right-hand side: <------------0--======---->
             // No intersection, infeasible to propagate:
-            return Ok(None);
+            Ok(None)
         }
     }
 
@@ -1579,7 +1601,7 @@ impl Display for NullableInterval {
 
 impl From<&Interval> for NullableInterval {
     fn from(value: &Interval) -> Self {
-        if value.lower().is_null() && value.upper().is_null() {
+        if value.is_null() {
             Self::Null {
                 datatype: value.data_type(),
             }
@@ -2488,6 +2510,84 @@ mod tests {
         ];
         for (first, second) in empty_cases {
             assert_eq!(first.intersect(second)?, None)
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_union() -> Result<()> {
+        let possible_cases: Vec<(Interval, Interval, Interval)> = vec![
+            (
+                Interval::make(Some(1000_i64), None)?,
+                Interval::make::<i64>(None, None)?,
+                Interval::make(Some(1000_i64), None)?,
+            ),
+            (
+                Interval::make(Some(1000_i64), None)?,
+                Interval::make(None, Some(1000_i64))?,
+                Interval::make(Some(1000_i64), Some(1000_i64))?,
+            ),
+            (
+                Interval::make(Some(1000_i64), None)?,
+                Interval::make(None, Some(2000_i64))?,
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+            ),
+            (
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+                Interval::make(Some(1000_i64), None)?,
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+            ),
+            (
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+                Interval::make(Some(1000_i64), Some(1500_i64))?,
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+            ),
+            (
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+                Interval::make(Some(500_i64), Some(1500_i64))?,
+                Interval::make(Some(500_i64), Some(2000_i64))?,
+            ),
+            (
+                Interval::make::<i64>(None, None)?,
+                Interval::make::<i64>(None, None)?,
+                Interval::make::<i64>(None, None)?,
+            ),
+            (
+                Interval::make(None, Some(2000_u64))?,
+                Interval::make(Some(500_u64), None)?,
+                Interval::make(Some(500_u64), Some(2000_u64))?,
+            ),
+            (
+                Interval::make(Some(0_u64), Some(0_u64))?,
+                Interval::make(Some(0_u64), None)?,
+                Interval::make(Some(0_u64), Some(0_u64))?,
+            ),
+            (
+                Interval::make(Some(1000.0_f32), None)?,
+                Interval::make(None, Some(1000.0_f32))?,
+                Interval::make(Some(1000.0_f32), Some(1000.0_f32))?,
+            ),
+            (
+                Interval::make(Some(1000.0_f32), Some(1500.0_f32))?,
+                Interval::make(Some(0.0_f32), Some(1500.0_f32))?,
+                Interval::make(Some(0.0_f32), Some(1500.0_f32))?,
+            ),
+            (
+                Interval::make(Some(-1000.0_f64), Some(1500.0_f64))?,
+                Interval::make(Some(-1500.0_f64), Some(2000.0_f64))?,
+                Interval::make(Some(-1500.0_f64), Some(2000.0_f64))?,
+            ),
+            (
+                Interval::make(Some(16.0_f64), Some(32.0_f64))?,
+                Interval::make(Some(32.0_f64), Some(64.0_f64))?,
+                Interval::make(Some(16.0_f64), Some(64.0_f64))?,
+            ),
+        ];
+        for (first, second, expected) in possible_cases {
+            let union = first.union(second.clone())?.unwrap();
+            println!("\nleft:{:?} right:{:?} \nunion: {} expected:{:?}", first, second, &union, expected);
+            assert_eq!(union, expected)
         }
 
         Ok(())

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -28,7 +28,7 @@ use arrow::compute::{cast_with_options, CastOptions};
 use arrow::datatypes::DataType;
 use arrow::datatypes::{IntervalUnit, TimeUnit};
 use datafusion_common::rounding::{alter_fp_rounding_mode, next_down, next_up};
-use datafusion_common::{internal_err, Result, ScalarValue};
+use datafusion_common::{internal_err, DataFusionError, Result, ScalarValue};
 
 macro_rules! get_extreme_value {
     ($extreme:ident, $value:expr) => {
@@ -845,6 +845,12 @@ pub fn apply_operator(op: &Operator, lhs: &Interval, rhs: &Interval) -> Result<I
         Operator::Minus => lhs.sub(rhs),
         Operator::Multiply => lhs.mul(rhs),
         Operator::Divide => lhs.div(rhs),
+        Operator::IsDistinctFrom | Operator::IsNotDistinctFrom => {
+            let nullable_interval = NullableInterval::from(lhs).apply_operator(op, &NullableInterval::from(rhs));
+            nullable_interval.and_then(|x|x.values()
+                .cloned()
+                .ok_or(DataFusionError::Internal("Unexpected null value interval".to_string())))
+        }
         _ => internal_err!("Interval arithmetic does not support the operator {op}"),
     }
 }
@@ -1564,6 +1570,18 @@ impl Display for NullableInterval {
                 write!(f, "NullableInterval: {} U {{NULL}}", values)
             }
             Self::NotNull { values } => write!(f, "NullableInterval: {}", values),
+        }
+    }
+}
+
+impl From<&Interval> for NullableInterval {
+    fn from(value: &Interval) -> Self {
+        if value.lower().is_null() && value.upper().is_null() {
+            Self::Null {
+                datatype: value.data_type(),
+            }
+        } else {
+            Self::MaybeNull { values: value.clone() }
         }
     }
 }

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -584,7 +584,7 @@ impl Interval {
         // New lower and upper bounds must always construct a valid interval.
         assert!(
             lower.is_null() || upper.is_null() || (lower <= upper),
-            "The intersection of two intervals can not be an invalid interval"
+            "The union of two intervals can not be an invalid interval"
         );
 
         Ok(Some(Self { lower, upper }))
@@ -847,6 +847,17 @@ impl Interval {
         Ok(Self {
             lower: self.upper().clone().arithmetic_negate()?,
             upper: self.lower().clone().arithmetic_negate()?,
+        })
+    }
+
+    pub fn boolean_negate(self) -> Result<Self> {
+        if self.data_type() != DataType::Boolean {
+            return internal_err!("Boolean negation is only supported for boolean intervals");
+        }
+
+        Ok(Self {
+            lower: self.lower().clone().boolean_negate()?,
+            upper: self.upper().clone().boolean_negate()?,
         })
     }
 }

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -289,10 +289,14 @@ impl Interval {
             DataType::Float32 => handle_float_intervals!(Float32, f32, lower, upper),
             DataType::Float64 => handle_float_intervals!(Float64, f64, lower, upper),
             // Lower bounds of unsigned integer null values are set to zero:
-            // DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 if lower.is_null() => Self {
-            //     lower: ScalarValue::new_zero(&lower.data_type()).unwrap(),
-            //     upper,
-            // },
+            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64
+                if lower.is_null() =>
+            {
+                Self {
+                    lower: ScalarValue::new_zero(&lower.data_type()).unwrap(),
+                    upper,
+                }
+            }
             // Other data types do not require standardization:
             _ => Self { lower, upper },
         }
@@ -2556,7 +2560,7 @@ mod tests {
             (
                 Interval::make(None, Some(2000_u64))?,
                 Interval::make(Some(500_u64), None)?,
-                Interval::make(Some(500_u64), Some(2000_u64))?,
+                Interval::make(Some(0_u64), Some(2000_u64))?,
             ),
             (
                 Interval::make(Some(0_u64), Some(0_u64))?,
@@ -2585,12 +2589,7 @@ mod tests {
             ),
         ];
         for (first, second, expected) in possible_cases {
-            let union = first.union(second.clone())?.unwrap();
-            println!(
-                "\nleft:{:?} right:{:?} \nunion: {} expected:{:?}",
-                first, second, &union, expected
-            );
-            assert_eq!(union, expected)
+            assert_eq!(first.union(second.clone())?.unwrap(), expected)
         }
 
         Ok(())

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -560,6 +560,11 @@ impl Interval {
         }
     }
 
+    /// Compute the union of this interval with the given interval.
+    ///
+    /// NOTE: This function only works with intervals of the same data type.
+    ///       Attempting to compare intervals of different data types will lead
+    ///       to an error.
     pub fn union<T: Borrow<Self>>(&self, other: T) -> Result<Option<Self>> {
         let rhs = other.borrow();
         if self.data_type().ne(&rhs.data_type()) {
@@ -570,16 +575,35 @@ impl Interval {
             );
         };
 
-        // If it is evident that the result is an empty interval, short-circuit
-        // and directly return `None`.
-        if (!(self.lower.is_null() || rhs.upper.is_null()) && self.lower > rhs.upper)
+        // If the upper bound of one side is less than the lower bound of
+        // the other side or vice versa, then the resulting interval is
+        // expanded accordingly. Note that, this can only happen if any
+        // side has a null value.
+        //
+        // Examples:
+        // [1, 2] ∪ [3, NULL] = [1, 3]
+        // [3, NULL] ∪ [1, NULL] = [1, 3]
+        // [3, NULL] ∪ [NULL, 1] = [1, 3]
+        let (lower, upper) = if (!(self.lower.is_null() || rhs.upper.is_null())
+            && self.lower > rhs.upper)
             || (!(self.upper.is_null() || rhs.lower.is_null()) && self.upper < rhs.lower)
         {
-            return Ok(None);
-        }
-
-        let lower = min_of_bounds(&self.lower, &rhs.lower);
-        let upper = max_of_bounds(&self.upper, &rhs.upper);
+            (
+                min_of_bounds(
+                    &min_of_bounds(&min_of_bounds(&self.lower, &rhs.lower), &self.upper),
+                    &rhs.upper,
+                ),
+                max_of_bounds(
+                    &max_of_bounds(&max_of_bounds(&self.lower, &rhs.lower), &self.upper),
+                    &rhs.upper,
+                ),
+            )
+        } else {
+            (
+                min_of_bounds(&self.lower, &rhs.lower),
+                max_of_bounds(&self.upper, &rhs.upper),
+            )
+        };
 
         // New lower and upper bounds must always construct a valid interval.
         assert!(
@@ -2760,13 +2784,28 @@ mod tests {
             ),
             (
                 Interval::make(Some(1000_i64), None)?,
-                Interval::make(None, Some(1000_i64))?,
-                Interval::make(Some(1000_i64), Some(1000_i64))?,
+                Interval::make(Some(1000_i64), None)?,
+                Interval::make(Some(1000_i64), None)?,
             ),
             (
                 Interval::make(Some(1000_i64), None)?,
                 Interval::make(None, Some(2000_i64))?,
                 Interval::make(Some(1000_i64), Some(2000_i64))?,
+            ),
+            (
+                Interval::make::<i64>(None, None)?,
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+            ),
+            (
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+                Interval::make::<i64>(None, None)?,
+                Interval::make(Some(1000_i64), Some(2000_i64))?,
+            ),
+            (
+                Interval::make::<i64>(None, None)?,
+                Interval::make::<i64>(None, None)?,
+                Interval::make::<i64>(None, None)?,
             ),
             (
                 Interval::make(Some(1000_i64), Some(2000_i64))?,
@@ -2784,9 +2823,14 @@ mod tests {
                 Interval::make(Some(500_i64), Some(2000_i64))?,
             ),
             (
-                Interval::make::<i64>(None, None)?,
-                Interval::make::<i64>(None, None)?,
-                Interval::make::<i64>(None, None)?,
+                Interval::make(Some(1000_i64), None)?,
+                Interval::make(None, Some(10_i64))?,
+                Interval::make(Some(10_i64), Some(1000_i64))?,
+            ),
+            (
+                Interval::make(Some(1000_i64), None)?,
+                Interval::make(Some(1_i64), Some(10_i64))?,
+                Interval::make(Some(1_i64), Some(1000_i64))?,
             ),
             (
                 Interval::make(None, Some(2000_u64))?,

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -922,7 +922,14 @@ fn sub_bounds<const UPPER: bool>(
     rhs: &ScalarValue,
 ) -> ScalarValue {
     if lhs.is_null() || rhs.is_null() {
-        return ScalarValue::try_from(dt).unwrap();
+        return Interval::make_unbounded(dt).unwrap().lower;
+        // return ScalarValue::try_from(dt).unwrap();
+        // } else if lhs.is_null() && dt.is_unsigned_integer() {
+        //     // null values for lower bounds are set to zero:
+        //     let sanitized_lower = ScalarValue::new_zero(dt).unwrap();
+        //     return sub_bounds::<UPPER>(dt, &sanitized_lower, rhs);
+        // } else if rhs.is_null() {
+        //     return sub_bounds::<UPPER>(dt, lhs, &ScalarValue::new_zero(dt).unwrap());
     }
 
     match dt {
@@ -1032,14 +1039,14 @@ fn handle_overflow<const UPPER: bool>(
     }
 }
 
-// This function should remain private since it may corrupt the an interval if
+// This function should remain private since it may corrupt an interval if
 // used without caution.
 fn next_value(value: ScalarValue) -> ScalarValue {
     use ScalarValue::*;
     value_transition!(MAX, true, value)
 }
 
-// This function should remain private since it may corrupt the an interval if
+// This function should remain private since it may corrupt an interval if
 // used without caution.
 fn prev_value(value: ScalarValue) -> ScalarValue {
     use ScalarValue::*;
@@ -1049,10 +1056,10 @@ fn prev_value(value: ScalarValue) -> ScalarValue {
 trait OneTrait: Sized + std::ops::Add + std::ops::Sub {
     fn one() -> Self;
 }
-macro_rules! impl_OneTrait{
+macro_rules! impl_one_trait {
     ($($m:ty),*) => {$( impl OneTrait for $m  { fn one() -> Self { 1 as $m } })*}
 }
-impl_OneTrait! {u8, u16, u32, u64, i8, i16, i32, i64, i128}
+impl_one_trait! {u8, u16, u32, u64, i8, i16, i32, i64, i128}
 
 impl OneTrait for IntervalDayTime {
     fn one() -> Self {

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -567,17 +567,23 @@ impl Interval {
     ///       to an error.
     pub fn union<T: Borrow<Self>>(&self, other: T) -> Result<Option<Self>> {
         let rhs = other.borrow();
+
         if self.data_type().ne(&rhs.data_type()) {
-            return internal_err!(
-                "Only intervals with the same data type are intersectable, lhs:{}, rhs:{}",
-                self.data_type(),
-                rhs.data_type()
-            );
+            get_result_type(&self.data_type(), &Operator::Plus, &rhs.data_type())
+                .map_err(|e|
+                    DataFusionError::Internal(
+                        format!(
+                            "Cannot coerce data types for interval union, lhs:{}, rhs:{}. internal error: {}",
+                            self.data_type(),
+                            rhs.data_type(),
+                            e
+                        ))
+                )?;
         };
 
         // If the upper bound of one side is less than the lower bound of
         // the other side or vice versa, then the resulting interval is
-        // expanded accordingly. Note that, this can only happen if any
+        // expanded accordingly. Note that, this can only happen if one
         // side has a null value.
         //
         // Examples:
@@ -622,13 +628,19 @@ impl Interval {
     ///       to an error.
     pub fn intersect<T: Borrow<Self>>(&self, other: T) -> Result<Option<Self>> {
         let rhs = other.borrow();
+
         if self.data_type().ne(&rhs.data_type()) {
-            return internal_err!(
-                "Only intervals with the same data type are intersectable, lhs:{}, rhs:{}",
-                self.data_type(),
-                rhs.data_type()
-            );
-        };
+            get_result_type(&self.data_type(), &Operator::Plus, &rhs.data_type())
+                .map_err(|e|
+                    DataFusionError::Internal(
+                        format!(
+                            "Cannot coerce data types for interval intersection, lhs:{}, rhs:{}. internal error: {}",
+                            self.data_type(),
+                            rhs.data_type(),
+                            e
+                        ))
+                )?;
+        }
 
         // If it is evident that the result is an empty interval, short-circuit
         // and directly return `None`.
@@ -910,7 +922,7 @@ pub fn apply_operator(op: &Operator, lhs: &Interval, rhs: &Interval) -> Result<I
         Operator::Divide => lhs.div(rhs),
         Operator::IsDistinctFrom | Operator::IsNotDistinctFrom => {
             NullableInterval::from(lhs)
-                .apply_operator(op, &NullableInterval::from(rhs))
+                .apply_operator(op, &rhs.into())
                 .and_then(|x| {
                     x.values().cloned().ok_or(DataFusionError::Internal(
                         "Unexpected null value interval".to_string(),
@@ -1646,8 +1658,12 @@ impl From<&Interval> for NullableInterval {
             Self::Null {
                 datatype: value.data_type(),
             }
-        } else {
+        } else if value.lower.is_null() || value.upper.is_null() {
             Self::MaybeNull {
+                values: value.clone(),
+            }
+        } else {
+            Self::NotNull {
                 values: value.clone(),
             }
         }
@@ -1889,9 +1905,7 @@ mod tests {
 
     use arrow::datatypes::DataType;
     use arrow_buffer::IntervalDayTime as ArrowIntervalDayTime;
-    use datafusion_common::ScalarValue::{
-        Date32, DurationSecond, IntervalDayTime, IntervalYearMonth, TimestampSecond,
-    };
+    use datafusion_common::ScalarValue::{Date32, DurationMillisecond, DurationSecond, IntervalDayTime, IntervalYearMonth, TimestampSecond};
     use datafusion_common::{Result, ScalarValue};
 
     #[test]
@@ -2730,6 +2744,17 @@ mod tests {
                 Interval::make(Some(32.0_f64), Some(64.0_f64))?,
                 Interval::make(Some(32.0_f64), Some(32.0_f64))?,
             ),
+            (
+                Interval::new(DurationSecond(Some(1)), DurationSecond(Some(10))),
+                Interval::new(
+                    DurationMillisecond(Some(1001)),
+                    DurationMillisecond(Some(1010)),
+                ),
+                Interval::new(
+                    DurationMillisecond(Some(1001)),
+                    DurationMillisecond(Some(1010)),
+                ),
+            ),
         ];
         for (first, second, expected) in possible_cases {
             assert_eq!(first.intersect(second)?.unwrap(), expected)
@@ -2861,6 +2886,17 @@ mod tests {
                 Interval::make(Some(16.0_f64), Some(32.0_f64))?,
                 Interval::make(Some(32.0_f64), Some(64.0_f64))?,
                 Interval::make(Some(16.0_f64), Some(64.0_f64))?,
+            ),
+            (
+                Interval::new(DurationSecond(Some(1)), DurationSecond(Some(10))),
+                Interval::new(
+                    DurationSecond(Some(10)),
+                    DurationSecond(Some(100)),
+                ),
+                Interval::new(
+                    DurationSecond(Some(1)),
+                    DurationSecond(Some(100)),
+                ),
             ),
         ];
         for (first, second, expected) in possible_cases {

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -871,10 +871,10 @@ pub fn apply_operator(op: &Operator, lhs: &Interval, rhs: &Interval) -> Result<I
             NullableInterval::from(lhs)
                 .apply_operator(op, &NullableInterval::from(rhs))
                 .and_then(|x| {
-                x.values().cloned().ok_or(DataFusionError::Internal(
-                    "Unexpected null value interval".to_string(),
-                ))
-            })
+                    x.values().cloned().ok_or(DataFusionError::Internal(
+                        "Unexpected null value interval".to_string(),
+                    ))
+                })
         }
         _ => internal_err!("Interval arithmetic does not support the operator {op}"),
     }
@@ -1218,7 +1218,7 @@ pub fn satisfy_greater(
             // Right-hand side: <------------0--======---->
             // No intersection, infeasible to propagate:
             Ok(None)
-        }
+        };
     }
 
     // Only the lower bound of left hand side and the upper bound of the right
@@ -2586,7 +2586,10 @@ mod tests {
         ];
         for (first, second, expected) in possible_cases {
             let union = first.union(second.clone())?.unwrap();
-            println!("\nleft:{:?} right:{:?} \nunion: {} expected:{:?}", first, second, &union, expected);
+            println!(
+                "\nleft:{:?} right:{:?} \nunion: {} expected:{:?}",
+                first, second, &union, expected
+            );
             assert_eq!(union, expected)
         }
 

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -1905,7 +1905,10 @@ mod tests {
 
     use arrow::datatypes::DataType;
     use arrow_buffer::IntervalDayTime as ArrowIntervalDayTime;
-    use datafusion_common::ScalarValue::{Date32, DurationMillisecond, DurationSecond, IntervalDayTime, IntervalYearMonth, TimestampSecond};
+    use datafusion_common::ScalarValue::{
+        Date32, DurationMillisecond, DurationSecond, IntervalDayTime, IntervalYearMonth,
+        TimestampSecond,
+    };
     use datafusion_common::{Result, ScalarValue};
 
     #[test]
@@ -2889,14 +2892,8 @@ mod tests {
             ),
             (
                 Interval::new(DurationSecond(Some(1)), DurationSecond(Some(10))),
-                Interval::new(
-                    DurationSecond(Some(10)),
-                    DurationSecond(Some(100)),
-                ),
-                Interval::new(
-                    DurationSecond(Some(1)),
-                    DurationSecond(Some(100)),
-                ),
+                Interval::new(DurationSecond(Some(10)), DurationSecond(Some(100))),
+                Interval::new(DurationSecond(Some(1)), DurationSecond(Some(100))),
             ),
         ];
         for (first, second, expected) in possible_cases {

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -852,7 +852,9 @@ impl Interval {
 
     pub fn boolean_negate(self) -> Result<Self> {
         if self.data_type() != DataType::Boolean {
-            return internal_err!("Boolean negation is only supported for boolean intervals");
+            return internal_err!(
+                "Boolean negation is only supported for boolean intervals"
+            );
         }
 
         Ok(Self {
@@ -1863,8 +1865,10 @@ mod tests {
 
     use arrow::datatypes::DataType;
     use arrow_buffer::IntervalDayTime as ArrowIntervalDayTime;
+    use datafusion_common::ScalarValue::{
+        Date32, DurationSecond, IntervalDayTime, IntervalYearMonth, TimestampSecond,
+    };
     use datafusion_common::{Result, ScalarValue};
-    use datafusion_common::ScalarValue::{Date32, DurationSecond, IntervalDayTime, IntervalYearMonth, TimestampSecond};
 
     #[test]
     fn test_next_prev_value() -> Result<()> {
@@ -2087,15 +2091,30 @@ mod tests {
             ),
             (
                 Interval::new(ScalarValue::Date64(Some(1)), ScalarValue::Date64(Some(1))),
-                Interval::new(ScalarValue::Date64(Some(-1)), ScalarValue::Date64(Some(-1))),
+                Interval::new(
+                    ScalarValue::Date64(Some(-1)),
+                    ScalarValue::Date64(Some(-1)),
+                ),
             ),
             (
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
-                Interval::new(ScalarValue::TimestampSecond(Some(-10), None), ScalarValue::TimestampSecond(Some(-1), None)),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(10), None),
+                ),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(-10), None),
+                    ScalarValue::TimestampSecond(Some(-1), None),
+                ),
             ),
             (
-                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(10))),
-                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(-1))),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(1)),
+                    ScalarValue::DurationSecond(Some(10)),
+                ),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(-10)),
+                    ScalarValue::DurationSecond(Some(-1)),
+                ),
             ),
         ];
         for (first, second) in exactly_gt_cases {
@@ -2135,16 +2154,31 @@ mod tests {
                 )?,
             ),
             (
-                Interval::new(ScalarValue::Date64(Some(1)), ScalarValue::Date64(Some(10))),
+                Interval::new(
+                    ScalarValue::Date64(Some(1)),
+                    ScalarValue::Date64(Some(10)),
+                ),
                 Interval::new(ScalarValue::Date64(Some(1)), ScalarValue::Date64(Some(1))),
             ),
             (
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(1), None)),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(10), None),
+                ),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(1), None),
+                ),
             ),
             (
-                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(10))),
-                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(1))),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(1)),
+                    ScalarValue::DurationSecond(Some(10)),
+                ),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(1)),
+                    ScalarValue::DurationSecond(Some(1)),
+                ),
             ),
         ];
         for (first, second) in possibly_gt_cases {
@@ -2184,16 +2218,34 @@ mod tests {
                 )?,
             ),
             (
-                Interval::new(ScalarValue::Date64(Some(1)), ScalarValue::Date64(Some(10))),
-                Interval::new(ScalarValue::Date64(Some(10)), ScalarValue::Date64(Some(100))),
+                Interval::new(
+                    ScalarValue::Date64(Some(1)),
+                    ScalarValue::Date64(Some(10)),
+                ),
+                Interval::new(
+                    ScalarValue::Date64(Some(10)),
+                    ScalarValue::Date64(Some(100)),
+                ),
             ),
             (
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
-                Interval::new(ScalarValue::TimestampSecond(Some(10), None), ScalarValue::TimestampSecond(None, None)),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(10), None),
+                ),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(10), None),
+                    ScalarValue::TimestampSecond(None, None),
+                ),
             ),
             (
-                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(-1))),
-                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(1))),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(-10)),
+                    ScalarValue::DurationSecond(Some(-1)),
+                ),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(1)),
+                    ScalarValue::DurationSecond(Some(1)),
+                ),
             ),
         ];
         for (first, second) in not_gt_cases {
@@ -2242,16 +2294,34 @@ mod tests {
                 )?,
             ),
             (
-                Interval::new(ScalarValue::Time32Second(Some(0)), ScalarValue::Time32Second(Some(10))),
-                Interval::new(ScalarValue::Time32Second(Some(-1)), ScalarValue::Time32Second(Some(-1))),
+                Interval::new(
+                    ScalarValue::Time32Second(Some(0)),
+                    ScalarValue::Time32Second(Some(10)),
+                ),
+                Interval::new(
+                    ScalarValue::Time32Second(Some(-1)),
+                    ScalarValue::Time32Second(Some(-1)),
+                ),
             ),
             (
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(1), None)),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(10), None),
+                ),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(1), None),
+                ),
             ),
             (
-                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(1))),
-                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(-10))),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(-10)),
+                    ScalarValue::DurationSecond(Some(1)),
+                ),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(-10)),
+                    ScalarValue::DurationSecond(Some(-10)),
+                ),
             ),
         ];
         for (first, second) in exactly_gteq_cases {
@@ -2291,16 +2361,34 @@ mod tests {
                 )?,
             ),
             (
-                Interval::new(ScalarValue::Time32Second(Some(0)), ScalarValue::Time32Second(Some(10))),
-                Interval::new(ScalarValue::Time32Second(Some(0)), ScalarValue::Time32Second(None)),
+                Interval::new(
+                    ScalarValue::Time32Second(Some(0)),
+                    ScalarValue::Time32Second(Some(10)),
+                ),
+                Interval::new(
+                    ScalarValue::Time32Second(Some(0)),
+                    ScalarValue::Time32Second(None),
+                ),
             ),
             (
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(10), None),
+                ),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(10), None),
+                ),
             ),
             (
-                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(1))),
-                Interval::new(ScalarValue::DurationSecond(None), ScalarValue::DurationSecond(Some(0))),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(-10)),
+                    ScalarValue::DurationSecond(Some(1)),
+                ),
+                Interval::new(
+                    ScalarValue::DurationSecond(None),
+                    ScalarValue::DurationSecond(Some(0)),
+                ),
             ),
         ];
         for (first, second) in possibly_gteq_cases {
@@ -2336,16 +2424,34 @@ mod tests {
                 )?,
             ),
             (
-                Interval::new(ScalarValue::Time32Second(Some(-10)), ScalarValue::Time32Second(Some(0))),
-                Interval::new(ScalarValue::Time32Second(Some(1)), ScalarValue::Time32Second(Some(10))),
+                Interval::new(
+                    ScalarValue::Time32Second(Some(-10)),
+                    ScalarValue::Time32Second(Some(0)),
+                ),
+                Interval::new(
+                    ScalarValue::Time32Second(Some(1)),
+                    ScalarValue::Time32Second(Some(10)),
+                ),
             ),
             (
-                Interval::new(ScalarValue::TimestampSecond(Some(5), None), ScalarValue::TimestampSecond(Some(9), None)),
-                Interval::new(ScalarValue::TimestampSecond(Some(10), None), ScalarValue::TimestampSecond(Some(100), None)),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(5), None),
+                    ScalarValue::TimestampSecond(Some(9), None),
+                ),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(10), None),
+                    ScalarValue::TimestampSecond(Some(100), None),
+                ),
             ),
             (
-                Interval::new(ScalarValue::DurationSecond(None), ScalarValue::DurationSecond(Some(-1))),
-                Interval::new(ScalarValue::DurationSecond(Some(0)), ScalarValue::DurationSecond(Some(1))),
+                Interval::new(
+                    ScalarValue::DurationSecond(None),
+                    ScalarValue::DurationSecond(Some(-1)),
+                ),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(0)),
+                    ScalarValue::DurationSecond(Some(1)),
+                ),
             ),
         ];
         for (first, second) in not_gteq_cases {
@@ -2376,20 +2482,44 @@ mod tests {
                 Interval::make(Some(f64::MIN), Some(f64::MIN))?,
             ),
             (
-                Interval::new(ScalarValue::Date64(Some(1000)), ScalarValue::Date64(Some(1000))),
-                Interval::new(ScalarValue::Date64(Some(1000)), ScalarValue::Date64(Some(1000))),
+                Interval::new(
+                    ScalarValue::Date64(Some(1000)),
+                    ScalarValue::Date64(Some(1000)),
+                ),
+                Interval::new(
+                    ScalarValue::Date64(Some(1000)),
+                    ScalarValue::Date64(Some(1000)),
+                ),
             ),
             (
-                Interval::new(ScalarValue::Time32Millisecond(Some(1000)), ScalarValue::Time32Millisecond(Some(1000))),
-                Interval::new(ScalarValue::Time32Millisecond(Some(1000)), ScalarValue::Time32Millisecond(Some(1000))),
+                Interval::new(
+                    ScalarValue::Time32Millisecond(Some(1000)),
+                    ScalarValue::Time32Millisecond(Some(1000)),
+                ),
+                Interval::new(
+                    ScalarValue::Time32Millisecond(Some(1000)),
+                    ScalarValue::Time32Millisecond(Some(1000)),
+                ),
             ),
             (
-                Interval::new(ScalarValue::IntervalYearMonth(Some(10)), ScalarValue::IntervalYearMonth(Some(10))),
-                Interval::new(ScalarValue::IntervalYearMonth(Some(10)), ScalarValue::IntervalYearMonth(Some(10))),
+                Interval::new(
+                    ScalarValue::IntervalYearMonth(Some(10)),
+                    ScalarValue::IntervalYearMonth(Some(10)),
+                ),
+                Interval::new(
+                    ScalarValue::IntervalYearMonth(Some(10)),
+                    ScalarValue::IntervalYearMonth(Some(10)),
+                ),
             ),
             (
-                Interval::new(ScalarValue::DurationSecond(Some(10)), ScalarValue::DurationSecond(Some(10))),
-                Interval::new(ScalarValue::DurationSecond(Some(10)), ScalarValue::DurationSecond(Some(10))),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(10)),
+                    ScalarValue::DurationSecond(Some(10)),
+                ),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(10)),
+                    ScalarValue::DurationSecond(Some(10)),
+                ),
             ),
         ];
         for (first, second) in exactly_eq_cases {
@@ -2710,13 +2840,25 @@ mod tests {
                 Interval::CERTAINLY_TRUE,
             ),
             (
-                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
-                Interval::new(ScalarValue::TimestampSecond(Some(2), None), ScalarValue::TimestampSecond(Some(5), None)),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(1), None),
+                    ScalarValue::TimestampSecond(Some(10), None),
+                ),
+                Interval::new(
+                    ScalarValue::TimestampSecond(Some(2), None),
+                    ScalarValue::TimestampSecond(Some(5), None),
+                ),
                 Interval::CERTAINLY_TRUE,
             ),
             (
-                Interval::new(ScalarValue::DurationSecond(Some(0)), ScalarValue::DurationSecond(Some(600))),
-                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(599))),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(0)),
+                    ScalarValue::DurationSecond(Some(600)),
+                ),
+                Interval::new(
+                    ScalarValue::DurationSecond(Some(1)),
+                    ScalarValue::DurationSecond(Some(599)),
+                ),
                 Interval::CERTAINLY_TRUE,
             ),
             (
@@ -2761,8 +2903,14 @@ mod tests {
                 Interval::CERTAINLY_FALSE,
             ),
             (
-                Interval::new(ScalarValue::Time32Second(Some(0)), ScalarValue::Time32Second(Some(60))),
-                Interval::new(ScalarValue::Time32Second(Some(61)), ScalarValue::Time32Second(Some(120))),
+                Interval::new(
+                    ScalarValue::Time32Second(Some(0)),
+                    ScalarValue::Time32Second(Some(60)),
+                ),
+                Interval::new(
+                    ScalarValue::Time32Second(Some(61)),
+                    ScalarValue::Time32Second(Some(120)),
+                ),
                 Interval::CERTAINLY_FALSE,
             ),
         ];
@@ -2842,19 +2990,28 @@ mod tests {
                 Interval::make(None, Some(300_f64))?,
             ),
             (
-                Interval::new(TimestampSecond(Some(100), None), TimestampSecond(Some(200), None)),
+                Interval::new(
+                    TimestampSecond(Some(100), None),
+                    TimestampSecond(Some(200), None),
+                ),
                 Interval::new(DurationSecond(Some(100)), DurationSecond(Some(200))),
-                Interval::new(TimestampSecond(Some(200), None), TimestampSecond(Some(400), None)),
+                Interval::new(
+                    TimestampSecond(Some(200), None),
+                    TimestampSecond(Some(400), None),
+                ),
             ),
             (
                 Interval::new(Date32(Some(100)), Date32(Some(100))),
-                Interval::new(IntervalDayTime(Some(ArrowIntervalDayTime{
-                    days: 1,
-                    milliseconds: 0,
-                })), IntervalDayTime(Some(ArrowIntervalDayTime{
-                    days: 10,
-                    milliseconds: 0,
-                }))),
+                Interval::new(
+                    IntervalDayTime(Some(ArrowIntervalDayTime {
+                        days: 1,
+                        milliseconds: 0,
+                    })),
+                    IntervalDayTime(Some(ArrowIntervalDayTime {
+                        days: 10,
+                        milliseconds: 0,
+                    })),
+                ),
                 Interval::new(Date32(Some(101)), Date32(Some(110))),
             ),
             (

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -846,10 +846,13 @@ pub fn apply_operator(op: &Operator, lhs: &Interval, rhs: &Interval) -> Result<I
         Operator::Multiply => lhs.mul(rhs),
         Operator::Divide => lhs.div(rhs),
         Operator::IsDistinctFrom | Operator::IsNotDistinctFrom => {
-            let nullable_interval = NullableInterval::from(lhs).apply_operator(op, &NullableInterval::from(rhs));
-            nullable_interval.and_then(|x|x.values()
-                .cloned()
-                .ok_or(DataFusionError::Internal("Unexpected null value interval".to_string())))
+            let nullable_interval = NullableInterval::from(lhs)
+                .apply_operator(op, &NullableInterval::from(rhs));
+            nullable_interval.and_then(|x| {
+                x.values().cloned().ok_or(DataFusionError::Internal(
+                    "Unexpected null value interval".to_string(),
+                ))
+            })
         }
         _ => internal_err!("Interval arithmetic does not support the operator {op}"),
     }
@@ -1581,7 +1584,9 @@ impl From<&Interval> for NullableInterval {
                 datatype: value.data_type(),
             }
         } else {
-            Self::MaybeNull { values: value.clone() }
+            Self::MaybeNull {
+                values: value.clone(),
+            }
         }
     }
 }

--- a/datafusion/expr/src/interval_arithmetic.rs
+++ b/datafusion/expr/src/interval_arithmetic.rs
@@ -933,14 +933,7 @@ fn sub_bounds<const UPPER: bool>(
     rhs: &ScalarValue,
 ) -> ScalarValue {
     if lhs.is_null() || rhs.is_null() {
-        return Interval::make_unbounded(dt).unwrap().lower;
-        // return ScalarValue::try_from(dt).unwrap();
-        // } else if lhs.is_null() && dt.is_unsigned_integer() {
-        //     // null values for lower bounds are set to zero:
-        //     let sanitized_lower = ScalarValue::new_zero(dt).unwrap();
-        //     return sub_bounds::<UPPER>(dt, &sanitized_lower, rhs);
-        // } else if rhs.is_null() {
-        //     return sub_bounds::<UPPER>(dt, lhs, &ScalarValue::new_zero(dt).unwrap());
+        return ScalarValue::try_from(dt).unwrap();
     }
 
     match dt {
@@ -1869,7 +1862,9 @@ mod tests {
     use crate::interval_arithmetic::{next_value, prev_value, satisfy_greater, Interval};
 
     use arrow::datatypes::DataType;
+    use arrow_buffer::IntervalDayTime as ArrowIntervalDayTime;
     use datafusion_common::{Result, ScalarValue};
+    use datafusion_common::ScalarValue::{Date32, DurationSecond, IntervalDayTime, IntervalYearMonth, TimestampSecond};
 
     #[test]
     fn test_next_prev_value() -> Result<()> {
@@ -2090,6 +2085,18 @@ mod tests {
                     prev_value(ScalarValue::Float32(Some(-1.0))),
                 )?,
             ),
+            (
+                Interval::new(ScalarValue::Date64(Some(1)), ScalarValue::Date64(Some(1))),
+                Interval::new(ScalarValue::Date64(Some(-1)), ScalarValue::Date64(Some(-1))),
+            ),
+            (
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
+                Interval::new(ScalarValue::TimestampSecond(Some(-10), None), ScalarValue::TimestampSecond(Some(-1), None)),
+            ),
+            (
+                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(10))),
+                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(-1))),
+            ),
         ];
         for (first, second) in exactly_gt_cases {
             assert_eq!(first.gt(second.clone())?, Interval::CERTAINLY_TRUE);
@@ -2127,6 +2134,18 @@ mod tests {
                     ScalarValue::Float32(Some(-1.0_f32)),
                 )?,
             ),
+            (
+                Interval::new(ScalarValue::Date64(Some(1)), ScalarValue::Date64(Some(10))),
+                Interval::new(ScalarValue::Date64(Some(1)), ScalarValue::Date64(Some(1))),
+            ),
+            (
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(1), None)),
+            ),
+            (
+                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(10))),
+                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(1))),
+            ),
         ];
         for (first, second) in possibly_gt_cases {
             assert_eq!(first.gt(second.clone())?, Interval::UNCERTAIN);
@@ -2163,6 +2182,18 @@ mod tests {
                     ScalarValue::Float32(Some(-1.0_f32)),
                     next_value(ScalarValue::Float32(Some(-1.0_f32))),
                 )?,
+            ),
+            (
+                Interval::new(ScalarValue::Date64(Some(1)), ScalarValue::Date64(Some(10))),
+                Interval::new(ScalarValue::Date64(Some(10)), ScalarValue::Date64(Some(100))),
+            ),
+            (
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
+                Interval::new(ScalarValue::TimestampSecond(Some(10), None), ScalarValue::TimestampSecond(None, None)),
+            ),
+            (
+                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(-1))),
+                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(1))),
             ),
         ];
         for (first, second) in not_gt_cases {
@@ -2210,6 +2241,18 @@ mod tests {
                     ScalarValue::Float32(Some(-1.0)),
                 )?,
             ),
+            (
+                Interval::new(ScalarValue::Time32Second(Some(0)), ScalarValue::Time32Second(Some(10))),
+                Interval::new(ScalarValue::Time32Second(Some(-1)), ScalarValue::Time32Second(Some(-1))),
+            ),
+            (
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(1), None)),
+            ),
+            (
+                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(1))),
+                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(-10))),
+            ),
         ];
         for (first, second) in exactly_gteq_cases {
             assert_eq!(first.gt_eq(second.clone())?, Interval::CERTAINLY_TRUE);
@@ -2247,6 +2290,18 @@ mod tests {
                     next_value(ScalarValue::Float32(Some(-1.0_f32))),
                 )?,
             ),
+            (
+                Interval::new(ScalarValue::Time32Second(Some(0)), ScalarValue::Time32Second(Some(10))),
+                Interval::new(ScalarValue::Time32Second(Some(0)), ScalarValue::Time32Second(None)),
+            ),
+            (
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
+            ),
+            (
+                Interval::new(ScalarValue::DurationSecond(Some(-10)), ScalarValue::DurationSecond(Some(1))),
+                Interval::new(ScalarValue::DurationSecond(None), ScalarValue::DurationSecond(Some(0))),
+            ),
         ];
         for (first, second) in possibly_gteq_cases {
             assert_eq!(first.gt_eq(second.clone())?, Interval::UNCERTAIN);
@@ -2280,6 +2335,18 @@ mod tests {
                     next_value(ScalarValue::Float32(Some(-1.0))),
                 )?,
             ),
+            (
+                Interval::new(ScalarValue::Time32Second(Some(-10)), ScalarValue::Time32Second(Some(0))),
+                Interval::new(ScalarValue::Time32Second(Some(1)), ScalarValue::Time32Second(Some(10))),
+            ),
+            (
+                Interval::new(ScalarValue::TimestampSecond(Some(5), None), ScalarValue::TimestampSecond(Some(9), None)),
+                Interval::new(ScalarValue::TimestampSecond(Some(10), None), ScalarValue::TimestampSecond(Some(100), None)),
+            ),
+            (
+                Interval::new(ScalarValue::DurationSecond(None), ScalarValue::DurationSecond(Some(-1))),
+                Interval::new(ScalarValue::DurationSecond(Some(0)), ScalarValue::DurationSecond(Some(1))),
+            ),
         ];
         for (first, second) in not_gteq_cases {
             assert_eq!(first.gt_eq(second.clone())?, Interval::CERTAINLY_FALSE);
@@ -2307,6 +2374,22 @@ mod tests {
             (
                 Interval::make(Some(f64::MIN), Some(f64::MIN))?,
                 Interval::make(Some(f64::MIN), Some(f64::MIN))?,
+            ),
+            (
+                Interval::new(ScalarValue::Date64(Some(1000)), ScalarValue::Date64(Some(1000))),
+                Interval::new(ScalarValue::Date64(Some(1000)), ScalarValue::Date64(Some(1000))),
+            ),
+            (
+                Interval::new(ScalarValue::Time32Millisecond(Some(1000)), ScalarValue::Time32Millisecond(Some(1000))),
+                Interval::new(ScalarValue::Time32Millisecond(Some(1000)), ScalarValue::Time32Millisecond(Some(1000))),
+            ),
+            (
+                Interval::new(ScalarValue::IntervalYearMonth(Some(10)), ScalarValue::IntervalYearMonth(Some(10))),
+                Interval::new(ScalarValue::IntervalYearMonth(Some(10)), ScalarValue::IntervalYearMonth(Some(10))),
+            ),
+            (
+                Interval::new(ScalarValue::DurationSecond(Some(10)), ScalarValue::DurationSecond(Some(10))),
+                Interval::new(ScalarValue::DurationSecond(Some(10)), ScalarValue::DurationSecond(Some(10))),
             ),
         ];
         for (first, second) in exactly_eq_cases {
@@ -2627,6 +2710,16 @@ mod tests {
                 Interval::CERTAINLY_TRUE,
             ),
             (
+                Interval::new(ScalarValue::TimestampSecond(Some(1), None), ScalarValue::TimestampSecond(Some(10), None)),
+                Interval::new(ScalarValue::TimestampSecond(Some(2), None), ScalarValue::TimestampSecond(Some(5), None)),
+                Interval::CERTAINLY_TRUE,
+            ),
+            (
+                Interval::new(ScalarValue::DurationSecond(Some(0)), ScalarValue::DurationSecond(Some(600))),
+                Interval::new(ScalarValue::DurationSecond(Some(1)), ScalarValue::DurationSecond(Some(599))),
+                Interval::CERTAINLY_TRUE,
+            ),
+            (
                 Interval::make(Some(1000_i64), None)?,
                 Interval::make::<i64>(None, None)?,
                 Interval::UNCERTAIN,
@@ -2665,6 +2758,11 @@ mod tests {
                     next_value(ScalarValue::Float32(Some(1.0))),
                 )?,
                 Interval::make(Some(1.0_f32), Some(1.0_f32))?,
+                Interval::CERTAINLY_FALSE,
+            ),
+            (
+                Interval::new(ScalarValue::Time32Second(Some(0)), ScalarValue::Time32Second(Some(60))),
+                Interval::new(ScalarValue::Time32Second(Some(61)), ScalarValue::Time32Second(Some(120))),
                 Interval::CERTAINLY_FALSE,
             ),
         ];
@@ -2742,6 +2840,32 @@ mod tests {
                 Interval::make(None, Some(100_f64))?,
                 Interval::make(None, Some(200_f64))?,
                 Interval::make(None, Some(300_f64))?,
+            ),
+            (
+                Interval::new(TimestampSecond(Some(100), None), TimestampSecond(Some(200), None)),
+                Interval::new(DurationSecond(Some(100)), DurationSecond(Some(200))),
+                Interval::new(TimestampSecond(Some(200), None), TimestampSecond(Some(400), None)),
+            ),
+            (
+                Interval::new(Date32(Some(100)), Date32(Some(100))),
+                Interval::new(IntervalDayTime(Some(ArrowIntervalDayTime{
+                    days: 1,
+                    milliseconds: 0,
+                })), IntervalDayTime(Some(ArrowIntervalDayTime{
+                    days: 10,
+                    milliseconds: 0,
+                }))),
+                Interval::new(Date32(Some(101)), Date32(Some(110))),
+            ),
+            (
+                Interval::new(DurationSecond(Some(100)), DurationSecond(Some(100))),
+                Interval::new(DurationSecond(Some(100)), DurationSecond(Some(100))),
+                Interval::new(DurationSecond(Some(200)), DurationSecond(Some(200))),
+            ),
+            (
+                Interval::new(IntervalYearMonth(Some(100)), IntervalYearMonth(Some(100))),
+                Interval::new(IntervalYearMonth(Some(100)), IntervalYearMonth(Some(100))),
+                Interval::new(IntervalYearMonth(Some(200)), IntervalYearMonth(Some(200))),
             ),
         ];
         for case in cases {

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -1035,6 +1035,7 @@ fn temporal_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataTyp
 
     match (lhs_type, rhs_type) {
         (Interval(_), Interval(_)) => Some(Interval(MonthDayNano)),
+        (Duration(_), Duration(_)) => Some(Duration(Nanosecond)),
         (Date64, Date32) | (Date32, Date64) => Some(Date64),
         (Timestamp(_, None), Date64) | (Date64, Timestamp(_, None)) => {
             Some(Timestamp(Nanosecond, None))
@@ -1105,6 +1106,7 @@ fn null_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
 
 #[cfg(test)]
 mod tests {
+    use arrow::datatypes::IntervalUnit::{MonthDayNano, YearMonth};
     use super::*;
 
     use datafusion_common::assert_contains;
@@ -1473,6 +1475,35 @@ mod tests {
             DataType::UInt32,
             Operator::BitwiseAnd,
             DataType::UInt32
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_type_coercion_temporal() -> Result<()> {
+        test_coercion_binary_rule!(
+            DataType::Duration(TimeUnit::Second),
+            DataType::Duration(TimeUnit::Second),
+            Operator::Plus,
+            DataType::Duration(TimeUnit::Second)
+        );
+        test_coercion_binary_rule!(
+            DataType::Duration(TimeUnit::Second),
+            DataType::Duration(TimeUnit::Nanosecond),
+            Operator::Plus,
+            DataType::Duration(TimeUnit::Nanosecond)
+        );
+        test_coercion_binary_rule!(
+            DataType::Interval(YearMonth),
+            DataType::Interval(YearMonth),
+            Operator::Plus,
+            DataType::Interval(YearMonth)
+        );
+        test_coercion_binary_rule!(
+            DataType::Interval(YearMonth),
+            DataType::Interval(MonthDayNano),
+            Operator::Plus,
+            DataType::Interval(MonthDayNano)
         );
         Ok(())
     }

--- a/datafusion/expr/src/type_coercion/binary.rs
+++ b/datafusion/expr/src/type_coercion/binary.rs
@@ -1106,8 +1106,8 @@ fn null_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Option<DataType> {
 
 #[cfg(test)]
 mod tests {
-    use arrow::datatypes::IntervalUnit::{MonthDayNano, YearMonth};
     use super::*;
+    use arrow::datatypes::IntervalUnit::{MonthDayNano, YearMonth};
 
     use datafusion_common::assert_contains;
 

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -686,4 +686,13 @@ impl ScalarUDFImpl for ScalarUdfLegacyWrapper {
     fn aliases(&self) -> &[String] {
         &[]
     }
+
+    fn evaluate_bounds(&self, input: &[&Interval]) -> Result<Interval> {
+        let arg_types = input
+            .iter()
+            .map(|i| i.data_type())
+            .collect::<Vec<DataType>>();
+        let return_type = self.return_type(&arg_types)?;
+        Interval::make_unbounded(&return_type)
+    }
 }

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -478,9 +478,10 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     ///
     /// If the function is `ABS(a)`, and the input interval is `a: [-3, 2]`,
     /// then the output interval would be `[0, 3]`.
-    fn evaluate_bounds(&self, _input: &[&Interval]) -> Result<Interval> {
-        // We cannot assume the input datatype is the same of output type.
-        Interval::make_unbounded(&DataType::Null)
+    fn evaluate_bounds(&self, input: &[&Interval]) -> Result<Interval> {
+        let input_data_types: &[DataType] = input.iter().map(|i| i.data_type()).collect();
+        let return_type = self.return_type(input_data_types)?;
+        Interval::make_unbounded(&return_type)
     }
 
     /// Updates bounds for child expressions, given a known interval for this
@@ -685,14 +686,5 @@ impl ScalarUDFImpl for ScalarUdfLegacyWrapper {
 
     fn aliases(&self) -> &[String] {
         &[]
-    }
-
-    fn evaluate_bounds(&self, input: &[&Interval]) -> Result<Interval> {
-        let arg_types = input
-            .iter()
-            .map(|i| i.data_type())
-            .collect::<Vec<DataType>>();
-        let return_type = self.return_type(&arg_types)?;
-        Interval::make_unbounded(&return_type)
     }
 }

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -479,7 +479,10 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     /// If the function is `ABS(a)`, and the input interval is `a: [-3, 2]`,
     /// then the output interval would be `[0, 3]`.
     fn evaluate_bounds(&self, input: &[&Interval]) -> Result<Interval> {
-        let input_data_types = input.iter().map(|i| i.data_type()).collect::<Vec<DataType>>();
+        let input_data_types = input
+            .iter()
+            .map(|i| i.data_type())
+            .collect::<Vec<DataType>>();
         let return_type = self.return_type(&input_data_types)?;
         Interval::make_unbounded(&return_type)
     }

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -479,8 +479,8 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
     /// If the function is `ABS(a)`, and the input interval is `a: [-3, 2]`,
     /// then the output interval would be `[0, 3]`.
     fn evaluate_bounds(&self, input: &[&Interval]) -> Result<Interval> {
-        let input_data_types: &[DataType] = input.iter().map(|i| i.data_type()).collect();
-        let return_type = self.return_type(input_data_types)?;
+        let input_data_types = input.iter().map(|i| i.data_type()).collect::<Vec<DataType>>();
+        let return_type = self.return_type(&input_data_types)?;
         Interval::make_unbounded(&return_type)
     }
 

--- a/datafusion/expr/src/udf.rs
+++ b/datafusion/expr/src/udf.rs
@@ -22,7 +22,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 
-use arrow::datatypes::DataType;
+use arrow::datatypes::{DataType, SchemaRef};
 
 use datafusion_common::{not_impl_err, ExprSchema, Result};
 
@@ -221,6 +221,11 @@ impl ScalarUDF {
     /// then the output interval would be `[0, 3]`.
     pub fn evaluate_bounds(&self, inputs: &[&Interval]) -> Result<Interval> {
         self.inner.evaluate_bounds(inputs)
+    }
+
+    /// Indicates whether this ['ScalarUDF'] supports interval arithmetic.
+    pub fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
+        self.inner.supports_bounds_evaluation(schema)
     }
 
     /// Updates bounds for child expressions, given a known interval for this
@@ -485,6 +490,11 @@ pub trait ScalarUDFImpl: Debug + Send + Sync {
             .collect::<Vec<DataType>>();
         let return_type = self.return_type(&input_data_types)?;
         Interval::make_unbounded(&return_type)
+    }
+
+    /// Indicates whether this ['ScalarUDFImpl'] supports interval arithmetic.
+    fn supports_bounds_evaluation(&self, _schema: &SchemaRef) -> bool {
+        false
     }
 
     /// Updates bounds for child expressions, given a known interval for this

--- a/datafusion/physical-expr-common/src/expressions/cast.rs
+++ b/datafusion/physical-expr-common/src/expressions/cast.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use crate::physical_expr::{down_cast_any_ref, PhysicalExpr};
 
 use arrow::compute::{can_cast_types, CastOptions};
-use arrow::datatypes::{DataType, DataType::*, Schema};
+use arrow::datatypes::{DataType, DataType::*, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::format::DEFAULT_FORMAT_OPTIONS;
 use datafusion_common::{not_impl_err, Result};
@@ -140,6 +140,10 @@ impl PhysicalExpr for CastExpr {
     fn evaluate_bounds(&self, children: &[&Interval]) -> Result<Interval> {
         // Cast current node's interval to the right type:
         children[0].cast_to(&self.cast_type, &self.cast_options)
+    }
+
+    fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
+        self.expr().supports_bounds_evaluation(schema)
     }
 
     fn propagate_constraints(

--- a/datafusion/physical-expr-common/src/expressions/column.rs
+++ b/datafusion/physical-expr-common/src/expressions/column.rs
@@ -25,10 +25,12 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use arrow::datatypes::SchemaRef;
 use datafusion_common::{internal_err, Result};
 use datafusion_expr::ColumnarValue;
 
 use crate::physical_expr::{down_cast_any_ref, PhysicalExpr};
+use crate::utils::is_supported_datatype_for_bounds_eval;
 
 /// Represents the column at a given index in a RecordBatch
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -101,6 +103,14 @@ impl PhysicalExpr for Column {
         _children: Vec<Arc<dyn PhysicalExpr>>,
     ) -> Result<Arc<dyn PhysicalExpr>> {
         Ok(self)
+    }
+
+    fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
+        if let Ok(field) = schema.field_with_name(self.name()) {
+            is_supported_datatype_for_bounds_eval(field.data_type())
+        } else {
+            false
+        }
     }
 
     fn dyn_hash(&self, state: &mut dyn Hasher) {

--- a/datafusion/physical-expr-common/src/expressions/column.rs
+++ b/datafusion/physical-expr-common/src/expressions/column.rs
@@ -21,11 +21,11 @@ use std::any::Any;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+use arrow::datatypes::SchemaRef;
 use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
-use arrow::datatypes::SchemaRef;
 use datafusion_common::{internal_err, Result};
 use datafusion_expr::ColumnarValue;
 

--- a/datafusion/physical-expr-common/src/physical_expr.rs
+++ b/datafusion/physical-expr-common/src/physical_expr.rs
@@ -24,7 +24,7 @@ use crate::utils::scatter;
 
 use arrow::array::BooleanArray;
 use arrow::compute::filter_record_batch;
-use arrow::datatypes::{DataType, Schema};
+use arrow::datatypes::{DataType, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use datafusion_common::{internal_err, not_impl_err, Result};
 use datafusion_expr::interval_arithmetic::Interval;
@@ -87,6 +87,11 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug + PartialEq<dyn Any> {
     /// and `b: [3, 4]`, then the output interval would be `[4, 6]`.
     fn evaluate_bounds(&self, _children: &[&Interval]) -> Result<Interval> {
         not_impl_err!("Not implemented for {self}")
+    }
+
+    /// Indicates whether interval arithmetic is supported for the given expression.
+    fn supports_bounds_evaluation(&self, _schema: &SchemaRef) -> bool {
+        false
     }
 
     /// Updates bounds for child expressions, given a known interval for this

--- a/datafusion/physical-expr-common/src/utils.rs
+++ b/datafusion/physical-expr-common/src/utils.rs
@@ -149,7 +149,7 @@ pub fn is_supported_datatype_for_bounds_eval(data_type: &DataType) -> bool {
             | &DataType::Float64
             | &DataType::Float32
             | &DataType::Float16
-            | &DataType::Timestamp(_,_)
+            | &DataType::Timestamp(_, _)
             | &DataType::Date32
             | &DataType::Date64
             | &DataType::Time32(_)

--- a/datafusion/physical-expr-common/src/utils.rs
+++ b/datafusion/physical-expr-common/src/utils.rs
@@ -24,7 +24,7 @@ use crate::tree_node::ExprContext;
 
 use arrow::array::{make_array, Array, ArrayRef, BooleanArray, MutableArrayData};
 use arrow::compute::{and_kleene, is_not_null, SlicesIterator};
-use arrow::datatypes::Schema;
+use arrow::datatypes::{DataType, Schema};
 use datafusion_common::{exec_err, Result};
 use datafusion_expr::sort_properties::ExprProperties;
 use datafusion_expr::Expr;
@@ -132,6 +132,31 @@ pub fn limited_convert_logical_expr_to_physical_expr(
             "Unsupported expression: {expr} for conversion to Arc<dyn PhysicalExpr>"
         ),
     }
+}
+
+/// Indicates whether interval arithmetic is supported for the given data type.
+pub fn is_supported_datatype_for_bounds_eval(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        &DataType::Int64
+            | &DataType::Int32
+            | &DataType::Int16
+            | &DataType::Int8
+            | &DataType::UInt64
+            | &DataType::UInt32
+            | &DataType::UInt16
+            | &DataType::UInt8
+            | &DataType::Float64
+            | &DataType::Float32
+            | &DataType::Float16
+            | &DataType::Timestamp(_,_)
+            | &DataType::Date32
+            | &DataType::Date64
+            | &DataType::Time32(_)
+            | &DataType::Time64(_)
+            | &DataType::Interval(_)
+            | &DataType::Duration(_)
+    )
 }
 
 #[cfg(test)]

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -41,12 +41,12 @@ use datafusion_expr::sort_properties::ExprProperties;
 use datafusion_expr::type_coercion::binary::get_result_type;
 use datafusion_expr::{ColumnarValue, Operator};
 
+use crate::intervals::utils::is_operator_supported;
 use kernels::{
     bitwise_and_dyn, bitwise_and_dyn_scalar, bitwise_or_dyn, bitwise_or_dyn_scalar,
     bitwise_shift_left_dyn, bitwise_shift_left_dyn_scalar, bitwise_shift_right_dyn,
     bitwise_shift_right_dyn_scalar, bitwise_xor_dyn, bitwise_xor_dyn_scalar,
 };
-use crate::intervals::utils::{is_operator_supported};
 
 /// Binary expression
 #[derive(Debug, Hash, Clone)]
@@ -330,7 +330,10 @@ impl PhysicalExpr for BinaryExpr {
 
     fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
         // Interval data types must be compatible for the given operation
-        if let (Ok(lhs), Ok(rhs)) = (self.left.data_type(schema.as_ref()), self.right.data_type(schema.as_ref())) {
+        if let (Ok(lhs), Ok(rhs)) = (
+            self.left.data_type(schema.as_ref()),
+            self.right.data_type(schema.as_ref()),
+        ) {
             if get_result_type(&lhs, &self.op, &rhs).is_err() {
                 return false;
             }

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -46,6 +46,7 @@ use kernels::{
     bitwise_shift_left_dyn, bitwise_shift_left_dyn_scalar, bitwise_shift_right_dyn,
     bitwise_shift_right_dyn_scalar, bitwise_xor_dyn, bitwise_xor_dyn_scalar,
 };
+use crate::intervals::utils::{is_operator_supported};
 
 /// Binary expression
 #[derive(Debug, Hash, Clone)]
@@ -325,6 +326,19 @@ impl PhysicalExpr for BinaryExpr {
             self.op,
             children[1].clone(),
         )))
+    }
+
+    fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
+        // Interval data types must be compatible for the given operation
+        if let (Ok(lhs), Ok(rhs)) = (self.left.data_type(schema.as_ref()), self.right.data_type(schema.as_ref())) {
+            if get_result_type(&lhs, &self.op, &rhs).is_err() {
+                return false;
+            }
+        }
+
+        is_operator_supported(&self.op)
+            && self.left.supports_bounds_evaluation(schema)
+            && self.right.supports_bounds_evaluation(schema)
     }
 
     fn evaluate_bounds(&self, children: &[&Interval]) -> Result<Interval> {

--- a/datafusion/physical-expr/src/expressions/binary.rs
+++ b/datafusion/physical-expr/src/expressions/binary.rs
@@ -41,7 +41,6 @@ use datafusion_expr::sort_properties::ExprProperties;
 use datafusion_expr::type_coercion::binary::get_result_type;
 use datafusion_expr::{ColumnarValue, Operator};
 
-use crate::intervals::utils::is_operator_supported;
 use kernels::{
     bitwise_and_dyn, bitwise_and_dyn_scalar, bitwise_or_dyn, bitwise_or_dyn_scalar,
     bitwise_shift_left_dyn, bitwise_shift_left_dyn_scalar, bitwise_shift_right_dyn,
@@ -79,6 +78,26 @@ impl BinaryExpr {
     /// Get the operator for this binary expression
     pub fn op(&self) -> &Operator {
         &self.op
+    }
+
+    /// Indicates whether interval arithmetic is supported for the given operator.
+    fn is_operator_supported(&self) -> bool {
+        matches!(
+            &self.op,
+            &Operator::Plus
+                | &Operator::Minus
+                | &Operator::And
+                | &Operator::Gt
+                | &Operator::GtEq
+                | &Operator::Lt
+                | &Operator::LtEq
+                | &Operator::Eq
+                | &Operator::NotEq
+                | &Operator::Multiply
+                | &Operator::Divide
+                | &Operator::IsDistinctFrom
+                | &Operator::IsNotDistinctFrom
+        )
     }
 }
 
@@ -339,7 +358,7 @@ impl PhysicalExpr for BinaryExpr {
             }
         }
 
-        is_operator_supported(&self.op)
+        self.is_operator_supported()
             && self.left.supports_bounds_evaluation(schema)
             && self.right.supports_bounds_evaluation(schema)
     }

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -42,6 +42,7 @@ use datafusion_common::{exec_err, internal_err, not_impl_err, Result, ScalarValu
 use datafusion_expr::ColumnarValue;
 
 use ahash::RandomState;
+use datafusion_expr::interval_arithmetic::Interval;
 use hashbrown::hash_map::RawEntryMut;
 use hashbrown::HashMap;
 
@@ -400,6 +401,33 @@ impl PhysicalExpr for InListExpr {
         self.negated.hash(&mut s);
         self.list.hash(&mut s);
         // Add `self.static_filter` when hash is available
+    }
+
+    /// Computes the output interval for the `InListExpr` expression,
+    /// given the input intervals.
+    ///
+    /// ```text
+    /// Full interval range of expr: ....---------------------....
+    /// Some list items:             .....|.......|.....|.|.......
+    /// New interval range:          .....|---------------|.......
+    /// ```
+    ///
+    /// If `negated` is true, the expr's interval range is returned.
+    fn evaluate_bounds(&self, children: &[&Interval]) -> Result<Interval> {
+        // children[0]: expr bounds
+        // children[1..]: list item bounds
+        let expr_bounds = children[0];
+        if self.negated {
+            return Ok(expr_bounds.clone());
+        }
+
+        let list_bound = children[1..]
+            .iter()
+            .try_fold(Some(children[1].clone()), |acc, item| {
+                acc.expect("children[1] must not be absent").union(*item)
+            })?;
+
+        Ok(list_bound.unwrap_or(Interval::make_unbounded(&expr_bounds.data_type())?))
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -414,22 +414,26 @@ impl PhysicalExpr for InListExpr {
     ///
     /// If `negated` is true, the expr's interval range is returned.
     fn evaluate_bounds(&self, children: &[&Interval]) -> Result<Interval> {
-        // children[0]: expr bounds
-        // children[1..]: list item bounds
         let expr_bounds = children[0];
-        if self.negated {
-            return Ok(expr_bounds.clone());
+
+        let mut list_bound = children[1].clone();
+        if children.len() > 2 {
+            list_bound = children[2..]
+                .iter()
+                .try_fold(Some(list_bound), |acc, item| {
+                    if let Some(acc) = acc {
+                        acc.union(*item)
+                    } else {
+                        Some(Interval::make_unbounded(&expr_bounds.data_type())).transpose()
+                    }
+                })?.unwrap_or(Interval::make_unbounded(&expr_bounds.data_type())?);
         }
 
-        let list_bound = children[1..]
-            .iter()
-            .try_fold(Some(children[1].clone()), |acc, item| {
-                acc.expect("children[1] must not be absent").union(*item)
-            })?;
-
-        let _input_interval = list_bound.unwrap_or(Interval::make_unbounded(&expr_bounds.data_type())?);
-
-        Interval::try_new(ScalarValue::Boolean(Some(false)), ScalarValue::Boolean(Some(true)))
+        if self.negated {
+            expr_bounds.contains(list_bound)?.boolean_negate()
+        } else {
+            expr_bounds.contains(list_bound)
+        }
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -432,9 +432,11 @@ impl PhysicalExpr for InListExpr {
                     if let Some(acc) = acc {
                         acc.union(*item)
                     } else {
-                        Some(Interval::make_unbounded(&expr_bounds.data_type())).transpose()
+                        Some(Interval::make_unbounded(&expr_bounds.data_type()))
+                            .transpose()
                     }
-                })?.unwrap_or(Interval::make_unbounded(&expr_bounds.data_type())?);
+                })?
+                .unwrap_or(Interval::make_unbounded(&expr_bounds.data_type())?);
         }
 
         if self.negated {
@@ -446,7 +448,10 @@ impl PhysicalExpr for InListExpr {
 
     fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
         self.expr.supports_bounds_evaluation(schema)
-            && self.list.iter().all(|expr| expr.supports_bounds_evaluation(schema))
+            && self
+                .list
+                .iter()
+                .all(|expr| expr.supports_bounds_evaluation(schema))
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -403,24 +403,32 @@ impl PhysicalExpr for InListExpr {
         // Add `self.static_filter` when hash is available
     }
 
-    /// Computes the output interval for the `InListExpr` expression,
-    /// given the input intervals.
+    /// The output interval is computed by checking if the list item intervals are
+    /// a subset of, overlap, or are disjoint with the input expression's interval.
+    ///
+    /// If [InListExpr::negated] is true, the output interval gets negated.
+    ///
+    /// # Example:
+    /// If the input expression's interval is a superset of the
+    /// conjunction of the list items intervals, the output
+    /// interval is [`CERTAINLY_TRUE`].
     ///
     /// ```text
-    /// Full interval range of expr: ....---------------------....
-    /// Some list items:             .....|.......|.....|.|.......
-    /// New interval range:          .....-----------------.......
+    /// interval of expr:   ....---------------------....
+    /// Some list items:    ..........|..|.....|.|.......
+    ///
+    /// output interval:    [`true`, `true`]
     /// ```
     ///
-    /// If `negated` is true, the expr's interval range is returned.
     fn evaluate_bounds(&self, children: &[&Interval]) -> Result<Interval> {
         let expr_bounds = children[0];
 
-        let mut list_bound = children[1].clone();
+        // conjunction of list item intervals
+        let mut list_bounds = children[1].clone();
         if children.len() > 2 {
-            list_bound = children[2..]
+            list_bounds = children[2..]
                 .iter()
-                .try_fold(Some(list_bound), |acc, item| {
+                .try_fold(Some(list_bounds), |acc, item| {
                     if let Some(acc) = acc {
                         acc.union(*item)
                     } else {
@@ -430,10 +438,15 @@ impl PhysicalExpr for InListExpr {
         }
 
         if self.negated {
-            expr_bounds.contains(list_bound)?.boolean_negate()
+            expr_bounds.contains(list_bounds)?.boolean_negate()
         } else {
-            expr_bounds.contains(list_bound)
+            expr_bounds.contains(list_bounds)
         }
+    }
+
+    fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
+        self.expr.supports_bounds_evaluation(schema)
+            && self.list.iter().all(|expr| expr.supports_bounds_evaluation(schema))
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -419,7 +419,6 @@ impl PhysicalExpr for InListExpr {
     ///
     /// output interval:    [`true`, `true`]
     /// ```
-    ///
     fn evaluate_bounds(&self, children: &[&Interval]) -> Result<Interval> {
         let expr_bounds = children[0];
 

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -411,7 +411,7 @@ impl PhysicalExpr for InListExpr {
     /// # Example:
     /// If the input expression's interval is a superset of the
     /// conjunction of the list items intervals, the output
-    /// interval is [`CERTAINLY_TRUE`].
+    /// interval is [`Interval::CERTAINLY_TRUE`].
     ///
     /// ```text
     /// interval of expr:   ....---------------------....

--- a/datafusion/physical-expr/src/expressions/in_list.rs
+++ b/datafusion/physical-expr/src/expressions/in_list.rs
@@ -409,7 +409,7 @@ impl PhysicalExpr for InListExpr {
     /// ```text
     /// Full interval range of expr: ....---------------------....
     /// Some list items:             .....|.......|.....|.|.......
-    /// New interval range:          .....|---------------|.......
+    /// New interval range:          .....-----------------.......
     /// ```
     ///
     /// If `negated` is true, the expr's interval range is returned.
@@ -427,7 +427,9 @@ impl PhysicalExpr for InListExpr {
                 acc.expect("children[1] must not be absent").union(*item)
             })?;
 
-        Ok(list_bound.unwrap_or(Interval::make_unbounded(&expr_bounds.data_type())?))
+        let _input_interval = list_bound.unwrap_or(Interval::make_unbounded(&expr_bounds.data_type())?);
+
+        Interval::try_new(ScalarValue::Boolean(Some(false)), ScalarValue::Boolean(Some(true)))
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/is_not_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_not_null.rs
@@ -28,8 +28,8 @@ use arrow::{
 };
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
-use datafusion_expr::ColumnarValue;
 use datafusion_expr::interval_arithmetic::Interval;
+use datafusion_expr::ColumnarValue;
 
 /// IS NOT NULL expression
 #[derive(Debug, Hash)]

--- a/datafusion/physical-expr/src/expressions/is_not_null.rs
+++ b/datafusion/physical-expr/src/expressions/is_not_null.rs
@@ -29,6 +29,7 @@ use arrow::{
 use datafusion_common::Result;
 use datafusion_common::ScalarValue;
 use datafusion_expr::ColumnarValue;
+use datafusion_expr::interval_arithmetic::Interval;
 
 /// IS NOT NULL expression
 #[derive(Debug, Hash)]
@@ -96,6 +97,17 @@ impl PhysicalExpr for IsNotNullExpr {
     fn dyn_hash(&self, state: &mut dyn Hasher) {
         let mut s = state;
         self.hash(&mut s);
+    }
+
+    fn evaluate_bounds(&self, children: &[&Interval]) -> Result<Interval> {
+        let inner = children[0];
+        Ok(if inner.is_null() {
+            Interval::CERTAINLY_FALSE
+        } else if inner.lower().is_null() || inner.upper().is_null() {
+            Interval::UNCERTAIN
+        } else {
+            Interval::CERTAINLY_TRUE
+        })
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/literal.rs
+++ b/datafusion/physical-expr/src/expressions/literal.rs
@@ -28,10 +28,12 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use arrow_schema::SchemaRef;
 use datafusion_common::{Result, ScalarValue};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::sort_properties::{ExprProperties, SortProperties};
 use datafusion_expr::{ColumnarValue, Expr};
+use datafusion_physical_expr_common::utils::is_supported_datatype_for_bounds_eval;
 
 /// Represents a literal value
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -96,6 +98,14 @@ impl PhysicalExpr for Literal {
             sort_properties: SortProperties::Singleton,
             range: Interval::try_new(self.value().clone(), self.value().clone())?,
         })
+    }
+
+    fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
+        if let Ok(dt) = self.data_type(schema) {
+            is_supported_datatype_for_bounds_eval(&dt)
+        } else {
+            false
+        }
     }
 }
 

--- a/datafusion/physical-expr/src/expressions/negative.rs
+++ b/datafusion/physical-expr/src/expressions/negative.rs
@@ -29,6 +29,7 @@ use arrow::{
     datatypes::{DataType, Schema},
     record_batch::RecordBatch,
 };
+use arrow_schema::SchemaRef;
 use datafusion_common::{plan_err, Result};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::sort_properties::ExprProperties;
@@ -113,6 +114,10 @@ impl PhysicalExpr for NegativeExpr {
             children[0].upper().arithmetic_negate()?,
             children[0].lower().arithmetic_negate()?,
         )
+    }
+
+    fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
+        self.arg().supports_bounds_evaluation(schema)
     }
 
     /// Returns a new [`Interval`] of a NegativeExpr  that has the existing `interval` given that

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -314,12 +314,14 @@ pub fn propagate_comparison(
 ) -> Result<Option<(Interval, Interval)>> {
     if parent == &Interval::CERTAINLY_TRUE {
         match op {
-            Operator::Eq | Operator::IsNotDistinctFrom => left_child.intersect(right_child).map(|result| {
-                result.map(|intersection| (intersection.clone(), intersection))
-            }),
-            Operator::NotEq | Operator::IsDistinctFrom => left_child.union(right_child).map(|result| {
-                result.map(|unin| (unin.clone(), unin))
-            }),
+            Operator::Eq | Operator::IsNotDistinctFrom => {
+                left_child.intersect(right_child).map(|result| {
+                    result.map(|intersection| (intersection.clone(), intersection))
+                })
+            }
+            Operator::NotEq | Operator::IsDistinctFrom => left_child
+                .union(right_child)
+                .map(|result| result.map(|unin| (unin.clone(), unin))),
             Operator::Gt => satisfy_greater(left_child, right_child, true),
             Operator::GtEq => satisfy_greater(left_child, right_child, false),
             Operator::Lt => satisfy_greater(right_child, left_child, true)
@@ -332,7 +334,10 @@ pub fn propagate_comparison(
         }
     } else if parent == &Interval::CERTAINLY_FALSE {
         match op {
-            Operator::Eq | Operator::IsNotDistinctFrom | Operator::NotEq | Operator::IsDistinctFrom => {
+            Operator::Eq
+            | Operator::IsNotDistinctFrom
+            | Operator::NotEq
+            | Operator::IsDistinctFrom => {
                 // TODO: Propagation is not possible until we support interval sets.
                 Ok(None)
             }

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -314,8 +314,11 @@ pub fn propagate_comparison(
 ) -> Result<Option<(Interval, Interval)>> {
     if parent == &Interval::CERTAINLY_TRUE {
         match op {
-            Operator::Eq => left_child.intersect(right_child).map(|result| {
+            Operator::Eq | Operator::IsNotDistinctFrom => left_child.intersect(right_child).map(|result| {
                 result.map(|intersection| (intersection.clone(), intersection))
+            }),
+            Operator::NotEq | Operator::IsDistinctFrom => left_child.union(right_child).map(|result| {
+                result.map(|unin| (unin.clone(), unin))
             }),
             Operator::Gt => satisfy_greater(left_child, right_child, true),
             Operator::GtEq => satisfy_greater(left_child, right_child, false),
@@ -329,7 +332,7 @@ pub fn propagate_comparison(
         }
     } else if parent == &Interval::CERTAINLY_FALSE {
         match op {
-            Operator::Eq => {
+            Operator::Eq | Operator::IsNotDistinctFrom | Operator::NotEq | Operator::IsDistinctFrom => {
                 // TODO: Propagation is not possible until we support interval sets.
                 Ok(None)
             }

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -37,7 +37,7 @@ use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::{DefaultIx, StableGraph};
 use petgraph::visit::{Bfs, Dfs, DfsPostOrder, EdgeRef};
 use petgraph::Outgoing;
-
+use datafusion_expr::type_coercion::{is_datetime, is_interval};
 // Interval arithmetic provides a way to perform mathematical operations on
 // intervals, which represent a range of possible values rather than a single
 // point value. This allows for the propagation of ranges through mathematical
@@ -223,42 +223,39 @@ pub fn propagate_arithmetic(
     right_child: &Interval,
 ) -> Result<Option<(Interval, Interval)>> {
     let inverse_op = get_inverse_op(*op)?;
-    match (left_child.data_type(), right_child.data_type()) {
-        // If we have a child whose type is a time interval (i.e. DataType::Interval),
-        // we need special handling since timestamp differencing results in a
-        // Duration type.
-        (DataType::Timestamp(..), DataType::Interval(_)) => {
-            propagate_time_interval_at_right(
-                left_child,
-                right_child,
-                parent,
-                op,
-                &inverse_op,
-            )
-        }
-        (DataType::Interval(_), DataType::Timestamp(..)) => {
-            propagate_time_interval_at_left(
-                left_child,
-                right_child,
-                parent,
-                op,
-                &inverse_op,
-            )
-        }
-        _ => {
-            // First, propagate to the left:
-            match apply_operator(&inverse_op, parent, right_child)?
-                .intersect(left_child)?
-            {
-                // Left is feasible:
-                Some(value) => Ok(
-                    // Propagate to the right using the new left.
-                    propagate_right(&value, parent, right_child, op, &inverse_op)?
-                        .map(|right| (value, right)),
-                ),
-                // If the left child is infeasible, short-circuit.
-                None => Ok(None),
-            }
+
+    // If we have a child whose data type is datetime (i.e. timestamp),
+    // we need special handling since timestamp differencing results in
+    // a Duration type.
+    if is_datetime(&left_child.data_type()) && is_interval(&right_child.data_type()) {
+        propagate_time_interval_at_right(
+            left_child,
+            right_child,
+            parent,
+            op,
+            &inverse_op,
+        )
+    } else if is_interval(&left_child.data_type()) && is_datetime(&right_child.data_type()) {
+        propagate_time_interval_at_left(
+            left_child,
+            right_child,
+            parent,
+            op,
+            &inverse_op,
+        )
+    } else {
+        // First, propagate to the left:
+        match apply_operator(&inverse_op, parent, right_child)?
+            .intersect(left_child)?
+        {
+            // Left is feasible:
+            Some(value) => Ok(
+                // Propagate to the right using the new left.
+                propagate_right(&value, parent, right_child, op, &inverse_op)?
+                    .map(|right| (value, right)),
+            ),
+            // If the left child is infeasible, short-circuit.
+            None => Ok(None),
         }
     }
 }

--- a/datafusion/physical-expr/src/intervals/cp_solver.rs
+++ b/datafusion/physical-expr/src/intervals/cp_solver.rs
@@ -33,11 +33,11 @@ use datafusion_common::{internal_err, Result};
 use datafusion_expr::interval_arithmetic::{apply_operator, satisfy_greater, Interval};
 use datafusion_expr::Operator;
 
+use datafusion_expr::type_coercion::{is_datetime, is_interval};
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::{DefaultIx, StableGraph};
 use petgraph::visit::{Bfs, Dfs, DfsPostOrder, EdgeRef};
 use petgraph::Outgoing;
-use datafusion_expr::type_coercion::{is_datetime, is_interval};
 // Interval arithmetic provides a way to perform mathematical operations on
 // intervals, which represent a range of possible values rather than a single
 // point value. This allows for the propagation of ranges through mathematical
@@ -228,26 +228,14 @@ pub fn propagate_arithmetic(
     // we need special handling since timestamp differencing results in
     // a Duration type.
     if is_datetime(&left_child.data_type()) && is_interval(&right_child.data_type()) {
-        propagate_time_interval_at_right(
-            left_child,
-            right_child,
-            parent,
-            op,
-            &inverse_op,
-        )
-    } else if is_interval(&left_child.data_type()) && is_datetime(&right_child.data_type()) {
-        propagate_time_interval_at_left(
-            left_child,
-            right_child,
-            parent,
-            op,
-            &inverse_op,
-        )
+        propagate_time_interval_at_right(left_child, right_child, parent, op, &inverse_op)
+    } else if is_interval(&left_child.data_type())
+        && is_datetime(&right_child.data_type())
+    {
+        propagate_time_interval_at_left(left_child, right_child, parent, op, &inverse_op)
     } else {
         // First, propagate to the left:
-        match apply_operator(&inverse_op, parent, right_child)?
-            .intersect(left_child)?
-        {
+        match apply_operator(&inverse_op, parent, right_child)?.intersect(left_child)? {
             // Left is feasible:
             Some(value) => Ok(
                 // Propagate to the right using the new left.

--- a/datafusion/physical-expr/src/intervals/utils.rs
+++ b/datafusion/physical-expr/src/intervals/utils.rs
@@ -17,50 +17,11 @@
 
 //! Utility functions for the interval arithmetic library
 
-use std::sync::Arc;
-
-use crate::{
-    expressions::{BinaryExpr, CastExpr, Column, Literal, NegativeExpr},
-    PhysicalExpr,
-};
-
 use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
-use arrow_schema::{DataType, SchemaRef};
+use arrow_schema::DataType;
 use datafusion_common::{internal_err, Result, ScalarValue};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::Operator;
-
-/// Indicates whether interval arithmetic is supported for the given expression.
-/// Currently, we do not support all [`PhysicalExpr`]s for interval calculations.
-/// We do not support every type of [`Operator`]s either. Over time, this check
-/// will relax as more types of `PhysicalExpr`s and `Operator`s are supported.
-/// Currently, [`CastExpr`], [`NegativeExpr`], [`BinaryExpr`], [`Column`] and [`Literal`] are supported.
-pub fn check_support(expr: &Arc<dyn PhysicalExpr>, schema: &SchemaRef) -> bool {
-    let expr_any = expr.as_any();
-    if let Some(binary_expr) = expr_any.downcast_ref::<BinaryExpr>() {
-        is_operator_supported(binary_expr.op())
-            && check_support(binary_expr.left(), schema)
-            && check_support(binary_expr.right(), schema)
-    } else if let Some(column) = expr_any.downcast_ref::<Column>() {
-        if let Ok(field) = schema.field_with_name(column.name()) {
-            is_datatype_supported(field.data_type())
-        } else {
-            return false;
-        }
-    } else if let Some(literal) = expr_any.downcast_ref::<Literal>() {
-        if let Ok(dt) = literal.data_type(schema) {
-            is_datatype_supported(&dt)
-        } else {
-            return false;
-        }
-    } else if let Some(cast) = expr_any.downcast_ref::<CastExpr>() {
-        check_support(cast.expr(), schema)
-    } else if let Some(negative) = expr_any.downcast_ref::<NegativeExpr>() {
-        check_support(negative.arg(), schema)
-    } else {
-        false
-    }
-}
 
 // This function returns the inverse operator of the given operator.
 pub fn get_inverse_op(op: Operator) -> Result<Operator> {
@@ -85,8 +46,11 @@ pub fn is_operator_supported(op: &Operator) -> bool {
             | &Operator::Lt
             | &Operator::LtEq
             | &Operator::Eq
+            | &Operator::NotEq
             | &Operator::Multiply
             | &Operator::Divide
+            | &Operator::IsDistinctFrom
+            | &Operator::IsNotDistinctFrom
     )
 }
 

--- a/datafusion/physical-expr/src/intervals/utils.rs
+++ b/datafusion/physical-expr/src/intervals/utils.rs
@@ -18,7 +18,6 @@
 //! Utility functions for the interval arithmetic library
 
 use arrow_buffer::{IntervalDayTime, IntervalMonthDayNano};
-use arrow_schema::DataType;
 use datafusion_common::{internal_err, Result, ScalarValue};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::Operator;
@@ -32,43 +31,6 @@ pub fn get_inverse_op(op: Operator) -> Result<Operator> {
         Operator::Divide => Ok(Operator::Multiply),
         _ => internal_err!("Interval arithmetic does not support the operator {}", op),
     }
-}
-
-/// Indicates whether interval arithmetic is supported for the given operator.
-pub fn is_operator_supported(op: &Operator) -> bool {
-    matches!(
-        op,
-        &Operator::Plus
-            | &Operator::Minus
-            | &Operator::And
-            | &Operator::Gt
-            | &Operator::GtEq
-            | &Operator::Lt
-            | &Operator::LtEq
-            | &Operator::Eq
-            | &Operator::NotEq
-            | &Operator::Multiply
-            | &Operator::Divide
-            | &Operator::IsDistinctFrom
-            | &Operator::IsNotDistinctFrom
-    )
-}
-
-/// Indicates whether interval arithmetic is supported for the given data type.
-pub fn is_datatype_supported(data_type: &DataType) -> bool {
-    matches!(
-        data_type,
-        &DataType::Int64
-            | &DataType::Int32
-            | &DataType::Int16
-            | &DataType::Int8
-            | &DataType::UInt64
-            | &DataType::UInt32
-            | &DataType::UInt16
-            | &DataType::UInt8
-            | &DataType::Float64
-            | &DataType::Float32
-    )
 }
 
 /// Converts an [`Interval`] of time intervals to one of `Duration`s, if applicable. Otherwise, returns [`None`].

--- a/datafusion/physical-expr/src/scalar_function.rs
+++ b/datafusion/physical-expr/src/scalar_function.rs
@@ -40,6 +40,7 @@ use crate::PhysicalExpr;
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 use arrow_array::Array;
+use arrow_schema::SchemaRef;
 use datafusion_common::{internal_err, DFSchema, Result, ScalarValue};
 use datafusion_expr::interval_arithmetic::Interval;
 use datafusion_expr::sort_properties::ExprProperties;
@@ -173,6 +174,10 @@ impl PhysicalExpr for ScalarFunctionExpr {
 
     fn evaluate_bounds(&self, children: &[&Interval]) -> Result<Interval> {
         self.fun.evaluate_bounds(children)
+    }
+
+    fn supports_bounds_evaluation(&self, schema: &SchemaRef) -> bool {
+        self.fun.supports_bounds_evaluation(schema)
     }
 
     fn propagate_constraints(

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -41,7 +41,6 @@ use datafusion_common::{plan_err, DataFusionError, Result};
 use datafusion_execution::TaskContext;
 use datafusion_expr::Operator;
 use datafusion_physical_expr::expressions::BinaryExpr;
-use datafusion_physical_expr::intervals::utils::check_support;
 use datafusion_physical_expr::utils::collect_columns;
 use datafusion_physical_expr::{
     analyze, split_conjunction, AnalysisContext, ExprBoundaries, PhysicalExpr,
@@ -124,7 +123,7 @@ impl FilterExec {
     ) -> Result<Statistics> {
         let input_stats = input.statistics()?;
         let schema = input.schema();
-        if !check_support(predicate, &schema) {
+        if !predicate.supports_bounds_evaluation(&schema) {
             let selectivity = default_selectivity as f64 / 100.0;
             let mut stats = input_stats.into_inexact();
             stats.num_rows = stats.num_rows.with_estimated_selectivity(selectivity);

--- a/datafusion/sqllogictest/test_files/dates.slt
+++ b/datafusion/sqllogictest/test_files/dates.slt
@@ -38,22 +38,25 @@ CREATE TABLE test(
 ;
 
 
-query error
+query T rowsort
 select i_item_desc
 from test
 where d3_date > d2_date + INTERVAL '1 days';
 ----
-DataFusion error: Internal error: Only intervals with the same data type are intersectable, lhs:Duration(Second), rhs:Interval(MonthDayNano).
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+c
+d
+e
+f
+g
+h
 
-
-query error
+query T rowsort
 select i_item_desc
 from test
 where d3_date > d2_date + INTERVAL '5 days';
 ----
-DataFusion error: Internal error: Only intervals with the same data type are intersectable, lhs:Duration(Second), rhs:Interval(MonthDayNano).
-This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+g
+h
 
 
 # date and other predicate

--- a/datafusion/sqllogictest/test_files/dates.slt
+++ b/datafusion/sqllogictest/test_files/dates.slt
@@ -38,25 +38,23 @@ CREATE TABLE test(
 ;
 
 
-query T rowsort
+query error
 select i_item_desc
 from test
 where d3_date > d2_date + INTERVAL '1 days';
 ----
-c
-d
-e
-f
-g
-h
+DataFusion error: Internal error: Only intervals with the same data type are intersectable, lhs:Duration(Second), rhs:Interval(MonthDayNano).
+This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
 
-query T rowsort
+
+query error
 select i_item_desc
 from test
 where d3_date > d2_date + INTERVAL '5 days';
 ----
-g
-h
+DataFusion error: Internal error: Only intervals with the same data type are intersectable, lhs:Duration(Second), rhs:Interval(MonthDayNano).
+This was likely caused by a bug in DataFusion's code and we would welcome that you file an bug report in our issue tracker
+
 
 # date and other predicate
 query T rowsort

--- a/datafusion/sqllogictest/test_files/repartition_scan.slt
+++ b/datafusion/sqllogictest/test_files/repartition_scan.slt
@@ -98,10 +98,11 @@ logical_plan
 02)--Filter: parquet_table.column1 != Int32(42)
 03)----TableScan: parquet_table projection=[column1], partial_filters=[parquet_table.column1 != Int32(42)]
 physical_plan
-01)CoalescePartitionsExec
-02)--CoalesceBatchesExec: target_batch_size=8192
-03)----FilterExec: column1@0 != 42
-04)------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..205], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:205..405, WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..5], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:5..210], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:210..414]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=CASE WHEN column1_null_count@2 = column1_row_count@3 THEN false ELSE column1_min@0 != 42 OR 42 != column1_max@1 END, required_guarantees=[column1 not in (42)]
+01)SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
+02)--SortExec: expr=[column1@0 ASC NULLS LAST], preserve_partitioning=[true]
+03)----CoalesceBatchesExec: target_batch_size=8192
+04)------FilterExec: column1@0 != 42
+05)--------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..205], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:205..405, WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..5], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:5..210], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:210..414]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=CASE WHEN column1_null_count@2 = column1_row_count@3 THEN false ELSE column1_min@0 != 42 OR 42 != column1_max@1 END, required_guarantees=[column1 not in (42)]
 
 
 ## Read the files as though they are ordered
@@ -134,7 +135,7 @@ logical_plan
 02)--Filter: parquet_table_with_order.column1 != Int32(42)
 03)----TableScan: parquet_table_with_order projection=[column1], partial_filters=[parquet_table_with_order.column1 != Int32(42)]
 physical_plan
-01)CoalescePartitionsExec
+01)SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: column1@0 != 42
 04)------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..207], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:207..414], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:202..405]]}, projection=[column1], output_ordering=[column1@0 ASC NULLS LAST], predicate=column1@0 != 42, pruning_predicate=CASE WHEN column1_null_count@2 = column1_row_count@3 THEN false ELSE column1_min@0 != 42 OR 42 != column1_max@1 END, required_guarantees=[column1 not in (42)]

--- a/datafusion/sqllogictest/test_files/repartition_scan.slt
+++ b/datafusion/sqllogictest/test_files/repartition_scan.slt
@@ -98,11 +98,10 @@ logical_plan
 02)--Filter: parquet_table.column1 != Int32(42)
 03)----TableScan: parquet_table projection=[column1], partial_filters=[parquet_table.column1 != Int32(42)]
 physical_plan
-01)SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
-02)--SortExec: expr=[column1@0 ASC NULLS LAST], preserve_partitioning=[true]
-03)----CoalesceBatchesExec: target_batch_size=8192
-04)------FilterExec: column1@0 != 42
-05)--------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..205], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:205..405, WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..5], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:5..210], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:210..414]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=CASE WHEN column1_null_count@2 = column1_row_count@3 THEN false ELSE column1_min@0 != 42 OR 42 != column1_max@1 END, required_guarantees=[column1 not in (42)]
+01)CoalescePartitionsExec
+02)--CoalesceBatchesExec: target_batch_size=8192
+03)----FilterExec: column1@0 != 42
+04)------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..205], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:205..405, WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..5], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:5..210], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:210..414]]}, projection=[column1], predicate=column1@0 != 42, pruning_predicate=CASE WHEN column1_null_count@2 = column1_row_count@3 THEN false ELSE column1_min@0 != 42 OR 42 != column1_max@1 END, required_guarantees=[column1 not in (42)]
 
 
 ## Read the files as though they are ordered
@@ -135,7 +134,7 @@ logical_plan
 02)--Filter: parquet_table_with_order.column1 != Int32(42)
 03)----TableScan: parquet_table_with_order projection=[column1], partial_filters=[parquet_table_with_order.column1 != Int32(42)]
 physical_plan
-01)SortPreservingMergeExec: [column1@0 ASC NULLS LAST]
+01)CoalescePartitionsExec
 02)--CoalesceBatchesExec: target_batch_size=8192
 03)----FilterExec: column1@0 != 42
 04)------ParquetExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:0..202], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:0..207], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/2.parquet:207..414], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/parquet_table/1.parquet:202..405]]}, projection=[column1], output_ordering=[column1@0 ASC NULLS LAST], predicate=column1@0 != 42, pruning_predicate=CASE WHEN column1_null_count@2 = column1_row_count@3 THEN false ELSE column1_min@0 != 42 OR 42 != column1_max@1 END, required_guarantees=[column1 not in (42)]


### PR DESCRIPTION
# Which issue does this PR close?

When evaluating column boundaries of filter predicates datafusion only supports non-null intervals. 

However, in DQE we convert `eq` operators into `IsNotDistinctFrom` operators which support null values and, subsequently, have nullable column bounds. This PR tries to handle this issue by converting between these two interval types.

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->