### PR TITLE
Bump object_store upper bound to 0.12.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4105,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781f96d79ed0f961a7021424ab01840efbda64ae7a505aaea195efc91eaaec4"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4592,7 +4592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4612,7 +4612,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4736,9 +4736,9 @@ checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
@@ -6940,7 +6940,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ hashbrown = { version = "0.14.5", features = ["raw"] }
 indexmap = ">=2.5.0, <=2.12.0"
 itertools = "0.14"
 log = "^0.4"
-object_store = { version = ">=0.12.0, <=0.12.2", default-features = false }
+object_store = { version = ">=0.12.0, <=0.12.5", default-features = false }
 parking_lot = "0.12"
 # parquet = { version = "55.2.0", default-features = false, features = [
 parquet = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", default-features = false, features = [


### PR DESCRIPTION
## Summary
- Raises the `object_store` version ceiling from `<=0.12.2` to `<=0.12.5`
- Provides the following fixes that may help with S3 PUT errors in DQE (CX-30069):
  - **Connection errors not retried** (0.12.4, apache/arrow-rs-object-store#445)
  - **Panic on body send** in `SpawnService` (0.12.4, apache/arrow-rs-object-store#442)
  - **Retry on HTTP 429/408** (0.12.3, apache/arrow-rs-object-store#426)
  - **Missing Content-Length on multipart init** (0.12.4, apache/arrow-rs-object-store#496)

## Test plan
- [x] `cargo check` passes in DQE with `object_store = "0.12.5"` and path deps to this branch
- [x] All 1755 DQE tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)