### PR TITLE
Allow setting terminator for `CsvDataSink` #21027

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -268,7 +268,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "bytes",
  "half",
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -366,7 +366,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "bitflags 2.8.0",
  "serde",
@@ -433,7 +433,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4211,7 +4211,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "55.0.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.0#6dacfada4a1d9445f327347908590c01013cb0fd"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.0.0-cx.1#1074e7c1ddb18ffc61190dbdd662fec9a8914d18"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,22 +87,22 @@ ahash = { version = "0.8", default-features = false, features = [
     "runtime-rng",
 ] }
 apache-avro = { version = "0.17", default-features = false }
-arrow = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", features = [
+arrow = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.1", features = [
     "prettyprint",
     "chrono-tz",
 ] }
-arrow-array = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", default-features = false, features = [
+arrow-array = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.1", default-features = false, features = [
     "chrono-tz",
 ] }
-arrow-buffer = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", default-features = false }
-arrow-flight = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", features = [
+arrow-buffer = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.1", default-features = false }
+arrow-flight = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.1", features = [
     "flight-sql-experimental",
 ] }
-arrow-ipc = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", default-features = false, features = [
+arrow-ipc = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.1", default-features = false, features = [
     "lz4",
 ] }
-arrow-ord = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", default-features = false }
-arrow-schema = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", default-features = false }
+arrow-ord = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.1", default-features = false }
+arrow-schema = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.1", default-features = false }
 async-trait = "0.1.73"
 bigdecimal = "0.4.7"
 bytes = "1.4"
@@ -156,7 +156,7 @@ log = "^0.4"
 object_store = { version = ">=0.12.0, <=0.12.5", default-features = false }
 parking_lot = "0.12"
 # parquet = { version = "55.2.0", default-features = false, features = [
-parquet = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.0", default-features = false, features = [
+parquet = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.0.0-cx.1", default-features = false, features = [
     "arrow",
     "async",
     "object_store",

--- a/datafusion/common/src/file_options/csv_writer.rs
+++ b/datafusion/common/src/file_options/csv_writer.rs
@@ -78,6 +78,11 @@ impl TryFrom<&CsvOptions> for CsvWriterOptions {
         if let Some(v) = &value.double_quote {
             builder = builder.with_double_quote(*v)
         }
+        let line_terminator = match value.terminator {
+            None => arrow::csv::writer::Terminator::CRLF,
+            Some(b) => arrow::csv::writer::Terminator::Any(b),
+        };
+        builder = builder.with_line_terminator(line_terminator);
         Ok(CsvWriterOptions {
             writer_options: builder,
             compression: value.compression,

--- a/datafusion/proto-common/proto/datafusion_common.proto
+++ b/datafusion/proto-common/proto/datafusion_common.proto
@@ -404,6 +404,8 @@ message CsvWriterOptions {
   string escape = 10;
   // Optional flag whether to double quotes, instead of escaping. Defaults to `true`
   bool double_quote = 11;
+  // Optional terminator character as bytes. E.g. `\r\n`, `\n`, `\r`. Defaults to `\r\n`
+  bytes terminator = 12;
 }
 
 // Options controlling CSV format

--- a/datafusion/proto-common/src/from_proto/mod.rs
+++ b/datafusion/proto-common/src/from_proto/mod.rs
@@ -23,6 +23,7 @@ use crate::common::proto_error;
 use crate::protobuf_common as protobuf;
 use arrow::array::{ArrayRef, AsArray};
 use arrow::buffer::Buffer;
+use arrow::csv::writer::Terminator;
 use arrow::csv::WriterBuilder;
 use arrow::datatypes::{
     i256, DataType, Field, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit,
@@ -1174,6 +1175,15 @@ pub(crate) fn csv_writer_options_from_proto(
             return Err(proto_error("Error parsing CSV Escape"));
         }
     }
+    let terminator = match &writer_options.terminator {
+        bytes if bytes.is_empty() || bytes.len() > 2 => {
+            return Err(proto_error(
+                "CSV Terminator must be a single byte character or a CRLF (\\r\\n)",
+            ))
+        }
+        bytes if *bytes == vec![b'\r', b'\n'] => Terminator::CRLF,
+        bytes => Terminator::Any(bytes[0]),
+    };
     Ok(builder
         .with_header(writer_options.has_header)
         .with_date_format(writer_options.date_format.clone())
@@ -1181,5 +1191,6 @@ pub(crate) fn csv_writer_options_from_proto(
         .with_timestamp_format(writer_options.timestamp_format.clone())
         .with_time_format(writer_options.time_format.clone())
         .with_null(writer_options.null_value.clone())
-        .with_double_quote(writer_options.double_quote))
+        .with_double_quote(writer_options.double_quote)
+        .with_line_terminator(terminator))
 }

--- a/datafusion/proto-common/src/generated/pbjson.rs
+++ b/datafusion/proto-common/src/generated/pbjson.rs
@@ -1960,6 +1960,9 @@ impl serde::Serialize for CsvWriterOptions {
         if self.double_quote {
             len += 1;
         }
+        if !self.terminator.is_empty() {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("datafusion_common.CsvWriterOptions", len)?;
         if self.compression != 0 {
             let v = CompressionTypeVariant::try_from(self.compression)
@@ -1996,6 +1999,11 @@ impl serde::Serialize for CsvWriterOptions {
         if self.double_quote {
             struct_ser.serialize_field("doubleQuote", &self.double_quote)?;
         }
+        if !self.terminator.is_empty() {
+            #[allow(clippy::needless_borrow)]
+            #[allow(clippy::needless_borrows_for_generic_args)]
+            struct_ser.serialize_field("terminator", pbjson::private::base64::encode(&self.terminator).as_str())?;
+        }
         struct_ser.end()
     }
 }
@@ -2024,6 +2032,7 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
             "escape",
             "double_quote",
             "doubleQuote",
+            "terminator",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -2039,6 +2048,7 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
             Quote,
             Escape,
             DoubleQuote,
+            Terminator,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -2071,6 +2081,7 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
                             "quote" => Ok(GeneratedField::Quote),
                             "escape" => Ok(GeneratedField::Escape),
                             "doubleQuote" | "double_quote" => Ok(GeneratedField::DoubleQuote),
+                            "terminator" => Ok(GeneratedField::Terminator),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -2101,6 +2112,7 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
                 let mut quote__ = None;
                 let mut escape__ = None;
                 let mut double_quote__ = None;
+                let mut terminator__ = None;
                 while let Some(k) = map_.next_key()? {
                     match k {
                         GeneratedField::Compression => {
@@ -2169,6 +2181,14 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
                             }
                             double_quote__ = Some(map_.next_value()?);
                         }
+                        GeneratedField::Terminator => {
+                            if terminator__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("terminator"));
+                            }
+                            terminator__ = 
+                                Some(map_.next_value::<::pbjson::private::BytesDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(CsvWriterOptions {
@@ -2183,6 +2203,7 @@ impl<'de> serde::Deserialize<'de> for CsvWriterOptions {
                     quote: quote__.unwrap_or_default(),
                     escape: escape__.unwrap_or_default(),
                     double_quote: double_quote__.unwrap_or_default(),
+                    terminator: terminator__.unwrap_or_default(),
                 })
             }
         }

--- a/datafusion/proto-common/src/generated/prost.rs
+++ b/datafusion/proto-common/src/generated/prost.rs
@@ -551,6 +551,9 @@ pub struct CsvWriterOptions {
     /// Optional flag whether to double quotes, instead of escaping. Defaults to `true`
     #[prost(bool, tag = "11")]
     pub double_quote: bool,
+    /// Optional terminator character as bytes. E.g. `\r\n`, `\n`, `\r`. Defaults to `\r\n`
+    #[prost(bytes = "vec", tag = "12")]
+    pub terminator: ::prost::alloc::vec::Vec<u8>,
 }
 /// Options controlling CSV format
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/datafusion/proto-common/src/to_proto/mod.rs
+++ b/datafusion/proto-common/src/to_proto/mod.rs
@@ -23,6 +23,7 @@ use crate::protobuf_common::{
     arrow_type::ArrowTypeEnum, scalar_value::Value, EmptyMessage,
 };
 use arrow::array::{ArrayRef, RecordBatch};
+use arrow::csv::writer::Terminator;
 use arrow::csv::WriterBuilder;
 use arrow::datatypes::{
     DataType, Field, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalUnit, Schema,
@@ -1046,6 +1047,10 @@ pub(crate) fn csv_writer_options_to_proto(
     compression: &CompressionTypeVariant,
 ) -> protobuf::CsvWriterOptions {
     let compression: protobuf::CompressionTypeVariant = compression.into();
+    let terminator = match csv_options.line_terminator() {
+        Terminator::CRLF => vec![b'\r', b'\n'],
+        Terminator::Any(c) => vec![*c],
+    };
     protobuf::CsvWriterOptions {
         compression: compression.into(),
         delimiter: (csv_options.delimiter() as char).to_string(),
@@ -1058,5 +1063,6 @@ pub(crate) fn csv_writer_options_to_proto(
         quote: (csv_options.quote() as char).to_string(),
         escape: (csv_options.escape() as char).to_string(),
         double_quote: csv_options.double_quote(),
+        terminator,
     }
 }

--- a/datafusion/proto/src/generated/datafusion_proto_common.rs
+++ b/datafusion/proto/src/generated/datafusion_proto_common.rs
@@ -551,6 +551,9 @@ pub struct CsvWriterOptions {
     /// Optional flag whether to double quotes, instead of escaping. Defaults to `true`
     #[prost(bool, tag = "11")]
     pub double_quote: bool,
+    /// Optional terminator character as bytes. E.g. `\r\n`, `\n`, `\r`. Defaults to `\r\n`
+    #[prost(bytes = "vec", tag = "12")]
+    pub terminator: ::prost::alloc::vec::Vec<u8>,
 }
 /// Options controlling CSV format
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -27,6 +27,7 @@ use crate::cases::{
 };
 
 use arrow::array::RecordBatch;
+use arrow::csv::writer::Terminator;
 use arrow::csv::WriterBuilder;
 use arrow::datatypes::{Fields, TimeUnit};
 use datafusion::physical_expr::aggregate::AggregateExprBuilder;
@@ -1406,6 +1407,125 @@ fn roundtrip_csv_sink() -> Result<()> {
         CompressionTypeVariant::ZSTD,
         csv_sink.writer_options().compression
     );
+
+    Ok(())
+}
+
+#[test]
+fn roundtrip_csv_sink_with_crlf_terminator() -> Result<()> {
+    let field_a = Field::new("plan_type", DataType::Utf8, false);
+    let field_b = Field::new("plan", DataType::Utf8, false);
+    let schema = Arc::new(Schema::new(vec![field_a, field_b]));
+    let input = Arc::new(PlaceholderRowExec::new(schema.clone()));
+
+    let file_sink_config = FileSinkConfig {
+        original_url: String::default(),
+        object_store_url: ObjectStoreUrl::local_filesystem(),
+        file_group: FileGroup::new(vec![PartitionedFile::new("/tmp".to_string(), 1)]),
+        table_paths: vec![ListingTableUrl::parse("file:///")?],
+        output_schema: schema.clone(),
+        table_partition_cols: vec![("plan_type".to_string(), DataType::Utf8)],
+        insert_op: InsertOp::Overwrite,
+        keep_partition_by_columns: true,
+        file_extension: "csv".into(),
+    };
+
+    let writer_builder = WriterBuilder::default().with_line_terminator(Terminator::CRLF);
+
+    let data_sink = Arc::new(CsvSink::new(
+        file_sink_config,
+        CsvWriterOptions::new(writer_builder, CompressionTypeVariant::UNCOMPRESSED),
+    ));
+    let sort_order = LexRequirement::new(vec![PhysicalSortRequirement::new(
+        Arc::new(Column::new("plan_type", 0)),
+        Some(SortOptions {
+            descending: true,
+            nulls_first: false,
+        }),
+    )]);
+
+    let ctx = SessionContext::new();
+    let codec = DefaultPhysicalExtensionCodec {};
+    let roundtrip_plan = roundtrip_test_and_return(
+        Arc::new(DataSinkExec::new(input, data_sink, Some(sort_order))),
+        &ctx,
+        &codec,
+    )
+    .unwrap();
+
+    let roundtrip_plan = roundtrip_plan
+        .as_any()
+        .downcast_ref::<DataSinkExec>()
+        .unwrap();
+    let csv_sink = roundtrip_plan
+        .sink()
+        .as_any()
+        .downcast_ref::<CsvSink>()
+        .unwrap();
+    match csv_sink.writer_options().writer_options.line_terminator() {
+        Terminator::CRLF => {}
+        other => panic!("Expected Terminator::CRLF, got {:?}", other),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn roundtrip_csv_sink_with_lf_terminator() -> Result<()> {
+    let field_a = Field::new("plan_type", DataType::Utf8, false);
+    let field_b = Field::new("plan", DataType::Utf8, false);
+    let schema = Arc::new(Schema::new(vec![field_a, field_b]));
+    let input = Arc::new(PlaceholderRowExec::new(schema.clone()));
+
+    let file_sink_config = FileSinkConfig {
+        original_url: String::default(),
+        object_store_url: ObjectStoreUrl::local_filesystem(),
+        file_group: FileGroup::new(vec![PartitionedFile::new("/tmp".to_string(), 1)]),
+        table_paths: vec![ListingTableUrl::parse("file:///")?],
+        output_schema: schema.clone(),
+        table_partition_cols: vec![("plan_type".to_string(), DataType::Utf8)],
+        insert_op: InsertOp::Overwrite,
+        keep_partition_by_columns: true,
+        file_extension: "csv".into(),
+    };
+
+    let writer_builder =
+        WriterBuilder::default().with_line_terminator(Terminator::Any(b'\n'));
+
+    let data_sink = Arc::new(CsvSink::new(
+        file_sink_config,
+        CsvWriterOptions::new(writer_builder, CompressionTypeVariant::UNCOMPRESSED),
+    ));
+    let sort_order = LexRequirement::new(vec![PhysicalSortRequirement::new(
+        Arc::new(Column::new("plan_type", 0)),
+        Some(SortOptions {
+            descending: true,
+            nulls_first: false,
+        }),
+    )]);
+
+    let ctx = SessionContext::new();
+    let codec = DefaultPhysicalExtensionCodec {};
+    let roundtrip_plan = roundtrip_test_and_return(
+        Arc::new(DataSinkExec::new(input, data_sink, Some(sort_order))),
+        &ctx,
+        &codec,
+    )
+    .unwrap();
+
+    let roundtrip_plan = roundtrip_plan
+        .as_any()
+        .downcast_ref::<DataSinkExec>()
+        .unwrap();
+    let csv_sink = roundtrip_plan
+        .sink()
+        .as_any()
+        .downcast_ref::<CsvSink>()
+        .unwrap();
+    match csv_sink.writer_options().writer_options.line_terminator() {
+        Terminator::Any(b'\n') => {}
+        other => panic!("Expected Terminator::Any(b'\\n'), got {:?}", other),
+    }
 
     Ok(())
 }

--- a/datafusion/sqllogictest/test_files/repartition_scan.slt
+++ b/datafusion/sqllogictest/test_files/repartition_scan.slt
@@ -185,7 +185,7 @@ logical_plan
 physical_plan
 01)CoalesceBatchesExec: target_batch_size=8192
 02)--FilterExec: column1@0 != 42
-03)----DataSourceExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/csv_table/1.csv:0..5], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/csv_table/1.csv:5..10], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/csv_table/1.csv:10..15], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/csv_table/1.csv:15..18]]}, projection=[column1], file_type=csv, has_header=true
+03)----DataSourceExec: file_groups={4 groups: [[WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/csv_table/1.csv:0..6], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/csv_table/1.csv:6..12], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/csv_table/1.csv:12..18], [WORKSPACE_ROOT/datafusion/sqllogictest/test_files/scratch/repartition_scan/csv_table/1.csv:18..24]]}, projection=[column1], file_type=csv, has_header=true
 
 # Cleanup
 statement ok


### PR DESCRIPTION
# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #21027

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Enable setting line terminator for CSV writer.

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`CsvWriterOptions` set terminator according to value in `CsvOptions`.

Assume same line terminator default for `CsvWriterOptions` as it is for `CsvReaderOptions` - CRLF. Previously `CsvWriterOptions` default was `\n`, and was ignoring `CsvOptions` terminator setting, unlike other settings.

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

Breaking change in CSV writer line terminator defaults, previously `\n`, now `\r\n` (same as default reader option).