### PR TITLE
Bump arrow to v55.1.0-cx.1 (BUGV2-5495 RowConverter fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,7 +232,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 [[package]]
 name = "arrow"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -268,7 +268,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "arrow-buffer"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "bytes",
  "half",
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -314,7 +314,7 @@ dependencies = [
 [[package]]
 name = "arrow-csv"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -340,7 +340,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -366,7 +366,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -379,7 +379,7 @@ dependencies = [
 [[package]]
 name = "arrow-json"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -412,7 +412,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -424,7 +424,7 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "bitflags 2.8.0",
  "serde",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "arrow-select"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4264,7 +4264,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "55.1.0"
-source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.0#147b6d00c24718fb0721ff4ecffa8a4a6d98c24e"
+source = "git+https://github.com/Coralogix/arrow-rs.git?tag=v55.1.0-cx.1#71878504590aa07e60c2afa1422fb6c188660c1a"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,22 +88,22 @@ ahash = { version = "0.8", default-features = false, features = [
     "runtime-rng",
 ] }
 apache-avro = { version = "0.17", default-features = false }
-arrow = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.0", features = [
+arrow = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.1", features = [
     "prettyprint",
     "chrono-tz",
 ] }
-arrow-array = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.0", default-features = false, features = [
+arrow-array = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.1", default-features = false, features = [
     "chrono-tz",
 ] }
-arrow-buffer = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.0", default-features = false }
-arrow-flight = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.0", features = [
+arrow-buffer = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.1", default-features = false }
+arrow-flight = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.1", features = [
     "flight-sql-experimental",
 ] }
-arrow-ipc = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.0", default-features = false, features = [
+arrow-ipc = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.1", default-features = false, features = [
     "lz4",
 ] }
-arrow-ord = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.0", default-features = false }
-arrow-schema = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.0", default-features = false }
+arrow-ord = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.1", default-features = false }
+arrow-schema = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.1", default-features = false }
 async-trait = "0.1.88"
 bigdecimal = "0.4.8"
 bytes = "1.10"
@@ -157,7 +157,7 @@ itertools = "0.14"
 log = "^0.4"
 object_store = { version = ">=0.12.0, <=0.12.5", default-features = false }
 parking_lot = "0.12"
-parquet = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.0", default-features = false, features = [
+parquet = { git = "https://github.com/Coralogix/arrow-rs.git", tag = "v55.1.0-cx.1", default-features = false, features = [
     "arrow",
     "async",
     "object_store",


### PR DESCRIPTION
Bumps arrow-rs dependency from `v55.1.0-cx.0` to `v55.1.0-cx.1`.

Picks up BUGV2-5495: Fix RowConverter panic with DictionaryArray in Struct/List (#77).

This fix was already on the v55.0.0-cx.2 branch (used by v47) but was missing from v55.1.0-cx.0 (used by v48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)