### PR TITLE
Make FilterExec cooperative for all-rows-rejected loops

### DIFF
--- a/datafusion/core/tests/execution/coop.rs
+++ b/datafusion/core/tests/execution/coop.rs
@@ -25,8 +25,10 @@ use datafusion::physical_plan;
 use datafusion::physical_plan::aggregates::{
     AggregateExec, AggregateMode, PhysicalGroupBy,
 };
-use datafusion::physical_plan::execution_plan::Boundedness;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::execution_plan::{
+    Boundedness, EmissionType, SchedulingType,
+};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion::prelude::SessionContext;
 use datafusion_common::{DataFusionError, JoinType, ScalarValue};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};
@@ -36,7 +38,7 @@ use datafusion_functions_aggregate::min_max;
 use datafusion_physical_expr::expressions::{
     binary, col, lit, BinaryExpr, Column, Literal,
 };
-use datafusion_physical_expr::Partitioning;
+use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion_physical_expr_common::physical_expr::PhysicalExpr;
 use datafusion_physical_expr_common::sort_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion_physical_optimizer::ensure_coop::EnsureCooperative;
@@ -109,6 +111,85 @@ impl LazyBatchGenerator for RangeBatchGenerator {
         let batch =
             RecordBatch::try_new(Arc::clone(&self.schema), vec![Arc::new(array)])?;
         Ok(Some(batch))
+    }
+}
+
+/// Test-only execution plan that emits an unbounded stream of identical
+/// batches and advertises [`SchedulingType::NonCooperative`]. The stream
+/// returns [`Poll::Ready`] on every poll and consumes no tokio
+/// cooperative-scheduling budget. Used by discriminating tests that need a
+/// child which cannot itself produce cooperative yield points, so any
+/// observed yielding must come from the operator under test.
+#[derive(Debug)]
+struct NonCooperativeInfiniteExec {
+    schema: SchemaRef,
+    batch: RecordBatch,
+    cache: PlanProperties,
+}
+
+impl NonCooperativeInfiniteExec {
+    fn new(schema: SchemaRef, batch: RecordBatch) -> Self {
+        let cache = PlanProperties::new(
+            EquivalenceProperties::new(Arc::clone(&schema)),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Incremental,
+            Boundedness::Unbounded {
+                requires_infinite_memory: false,
+            },
+        )
+        .with_scheduling_type(SchedulingType::NonCooperative);
+        Self {
+            schema,
+            batch,
+            cache,
+        }
+    }
+}
+
+impl DisplayAs for NonCooperativeInfiniteExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "NonCooperativeInfiniteExec")
+    }
+}
+
+impl ExecutionPlan for NonCooperativeInfiniteExec {
+    fn name(&self) -> &'static str {
+        "NonCooperativeInfiniteExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.cache
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> datafusion_common::Result<SendableRecordBatchStream> {
+        let batch = self.batch.clone();
+        let schema = Arc::clone(&self.schema);
+        let stream =
+            futures::stream::poll_fn(move |_cx| Poll::Ready(Some(Ok(batch.clone()))));
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
     }
 }
 
@@ -419,6 +500,41 @@ async fn filter_reject_all_batches_yields(
     let coalesced = Arc::new(CoalesceBatchesExec::new(filtered, 8_192));
 
     query_yields(coalesced, session_ctx.task_ctx()).await
+}
+
+#[tokio::test]
+async fn filter_reject_all_batches_yields_without_cooperative_input(
+) -> Result<(), Box<dyn Error>> {
+    // Discriminating test: the input leaf advertises NonCooperative and its
+    // stream consumes no coop budget. We deliberately skip
+    // `EnsureCooperative` so that nothing wraps the leaf, leaving FilterExec
+    // as the only possible source of cooperative yielding. If FilterExec
+    // did not yield on its own, this test would hang and the 10s timeout in
+    // `stream_yields` would fire.
+    let session_ctx = SessionContext::new();
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        DataType::Int64,
+        false,
+    )]));
+    let mut builder = Int64Array::builder(8192);
+    for v in i64::MIN..i64::MIN + 8192 {
+        builder.append_value(v);
+    }
+    let batch =
+        RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(builder.finish())])?;
+
+    let infinite = Arc::new(NonCooperativeInfiniteExec::new(schema, batch));
+
+    let false_predicate = Arc::new(BinaryExpr::new(
+        Arc::new(Column::new("value", 0)),
+        Gt,
+        Arc::new(Literal::new(ScalarValue::Int64(Some(i64::MAX)))),
+    ));
+    let filtered = Arc::new(FilterExec::try_new(false_predicate, infinite)?);
+
+    query_yields_no_ensure_cooperative(filtered, session_ctx.task_ctx()).await
 }
 
 #[rstest]
@@ -817,5 +933,16 @@ async fn query_yields(
     let stream = physical_plan::execute_stream(optimized, task_ctx)?;
 
     // Spawn a task that tries to poll the stream and check whether given stream yields
+    stream_yields(stream).await
+}
+
+/// Like [`query_yields`], but does not run `EnsureCooperative`. Used to
+/// verify that operators yield on their own when no other plan node
+/// participates in cooperative scheduling.
+async fn query_yields_no_ensure_cooperative(
+    plan: Arc<dyn ExecutionPlan>,
+    task_ctx: Arc<TaskContext>,
+) -> Result<(), Box<dyn Error>> {
+    let stream = physical_plan::execute_stream(plan, task_ctx)?;
     stream_yields(stream).await
 }

--- a/datafusion/core/tests/execution/coop.rs
+++ b/datafusion/core/tests/execution/coop.rs
@@ -28,7 +28,9 @@ use datafusion::physical_plan::aggregates::{
 use datafusion::physical_plan::execution_plan::{
     Boundedness, EmissionType, SchedulingType,
 };
-use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+};
 use datafusion::prelude::SessionContext;
 use datafusion_common::{DataFusionError, JoinType, ScalarValue};
 use datafusion_execution::{SendableRecordBatchStream, TaskContext};

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -27,6 +27,7 @@ use super::{
     RecordBatchStream, SendableRecordBatchStream, Statistics,
 };
 use crate::common::can_project;
+use crate::coop::make_cooperative;
 use crate::execution_plan::{CardinalityEffect, SchedulingType};
 use crate::filter_pushdown::{
     ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
@@ -63,17 +64,9 @@ use datafusion_physical_expr::{
 
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
 use futures::stream::{Stream, StreamExt};
-#[cfg(datafusion_coop = "tokio_fallback")]
-use futures::Future;
 use log::trace;
 
 const FILTER_EXEC_DEFAULT_SELECTIVITY: u8 = 20;
-
-/// Number of inner-loop iterations between cooperative yield checks
-/// when running with `--cfg datafusion_coop="per_stream"`. Mirrors the
-/// constant in `crate::coop` and matches Tokio's task budget.
-#[cfg(datafusion_coop = "per_stream")]
-const FILTER_YIELD_FREQUENCY: u8 = 128;
 
 /// FilterExec evaluates a boolean predicate against all input batches to determine which rows to
 /// include in its output batches.
@@ -312,10 +305,10 @@ impl FilterExec {
             input.pipeline_behavior(),
             input.boundedness(),
         )
-        // FilterExec inserts cooperative yield points in its `poll_next` so that
-        // an all-rows-rejected batch loop cannot monopolise a Tokio worker.
-        // Marking the plan cooperative also signals to `EnsureCooperative` that
-        // it does not need to wrap this operator.
+        // FilterExec wraps its input in `make_cooperative` so that an
+        // all-rows-rejected batch loop cannot monopolise a Tokio worker.
+        // Marking the plan cooperative also signals to `EnsureCooperative`
+        // that it does not need to wrap this operator.
         .with_scheduling_type(SchedulingType::Cooperative))
     }
 }
@@ -401,11 +394,9 @@ impl ExecutionPlan for FilterExec {
         Ok(Box::pin(FilterExecStream {
             schema: self.schema(),
             predicate: Arc::clone(&self.predicate),
-            input: self.input.execute(partition, context)?,
+            input: make_cooperative(self.input.execute(partition, context)?),
             baseline_metrics,
             projection: self.projection.clone(),
-            #[cfg(datafusion_coop = "per_stream")]
-            budget: FILTER_YIELD_FREQUENCY,
         }))
     }
 
@@ -641,12 +632,6 @@ struct FilterExecStream {
     baseline_metrics: BaselineMetrics,
     /// The projection indices of the columns in the input schema
     projection: Option<Vec<usize>>,
-    /// Cooperative-scheduling counter for `--cfg datafusion_coop="per_stream"`.
-    /// Decremented once per processed input batch; when it reaches zero the
-    /// stream yields to the runtime so the task remains cancellable even when
-    /// the predicate rejects every row.
-    #[cfg(datafusion_coop = "per_stream")]
-    budget: u8,
 }
 
 pub fn batch_filter(
@@ -698,36 +683,6 @@ impl Stream for FilterExecStream {
     ) -> Poll<Option<Self::Item>> {
         let poll;
         loop {
-            // Cooperative yield point: re-checked on every iteration so a
-            // predicate that rejects all rows in a batch cannot monopolise
-            // the worker. Mirrors `crate::coop::CooperativeStream::poll_next`
-            // for each of the three `cfg(datafusion_coop)` modes.
-            #[cfg(any(
-                datafusion_coop = "tokio",
-                not(any(
-                    datafusion_coop = "tokio_fallback",
-                    datafusion_coop = "per_stream"
-                ))
-            ))]
-            let coop = std::task::ready!(tokio::task::coop::poll_proceed(cx));
-
-            #[cfg(datafusion_coop = "tokio_fallback")]
-            {
-                if !tokio::task::coop::has_budget_remaining() {
-                    cx.waker().wake_by_ref();
-                    return Poll::Pending;
-                }
-            }
-
-            #[cfg(datafusion_coop = "per_stream")]
-            {
-                if self.budget == 0 {
-                    self.budget = FILTER_YIELD_FREQUENCY;
-                    cx.waker().wake_by_ref();
-                    return Poll::Pending;
-                }
-            }
-
             match ready!(self.input.poll_next_unpin(cx)) {
                 Some(Ok(batch)) => {
                     let timer = self.baseline_metrics.elapsed_compute().timer();
@@ -738,35 +693,6 @@ impl Stream for FilterExecStream {
                         &self.schema,
                     )?;
                     timer.done();
-
-                    // Account for the work that was just performed. This must
-                    // happen on both the empty-batch (continue) and non-empty
-                    // (return Ready) paths so that every predicate evaluation
-                    // counts toward the cooperative budget.
-                    #[cfg(any(
-                        datafusion_coop = "tokio",
-                        not(any(
-                            datafusion_coop = "tokio_fallback",
-                            datafusion_coop = "per_stream"
-                        ))
-                    ))]
-                    coop.made_progress();
-
-                    #[cfg(datafusion_coop = "tokio_fallback")]
-                    {
-                        // We've already done the work; consume one budget unit
-                        // by polling `consume_budget` once. Mirrors the pattern
-                        // in `crate::coop::CooperativeStream::poll_next`.
-                        let consume = tokio::task::coop::consume_budget();
-                        let consume_ref = std::pin::pin!(consume);
-                        let _ = consume_ref.poll(cx);
-                    }
-
-                    #[cfg(datafusion_coop = "per_stream")]
-                    {
-                        self.budget -= 1;
-                    }
-
                     // Skip entirely filtered batches
                     if filtered_batch.num_rows() == 0 {
                         continue;
@@ -775,10 +701,6 @@ impl Stream for FilterExecStream {
                     break;
                 }
                 value => {
-                    // Input ended or errored: do not record progress. In the
-                    // `tokio` mode the `coop` guard is dropped without
-                    // `made_progress`, restoring the budget unit reserved on
-                    // entry; this matches `CooperativeStream`'s behaviour.
                     poll = Poll::Ready(value);
                     break;
                 }

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -62,9 +62,9 @@ use datafusion_physical_expr::{
 };
 
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
+use futures::stream::{Stream, StreamExt};
 #[cfg(datafusion_coop = "tokio_fallback")]
 use futures::Future;
-use futures::stream::{Stream, StreamExt};
 use log::trace;
 
 const FILTER_EXEC_DEFAULT_SELECTIVITY: u8 = 20;

--- a/datafusion/physical-plan/src/filter.rs
+++ b/datafusion/physical-plan/src/filter.rs
@@ -27,7 +27,7 @@ use super::{
     RecordBatchStream, SendableRecordBatchStream, Statistics,
 };
 use crate::common::can_project;
-use crate::execution_plan::CardinalityEffect;
+use crate::execution_plan::{CardinalityEffect, SchedulingType};
 use crate::filter_pushdown::{
     ChildFilterDescription, ChildPushdownResult, FilterDescription, FilterPushdownPhase,
     FilterPushdownPropagation, PushedDown, PushedDownPredicate,
@@ -62,10 +62,18 @@ use datafusion_physical_expr::{
 };
 
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
+#[cfg(datafusion_coop = "tokio_fallback")]
+use futures::Future;
 use futures::stream::{Stream, StreamExt};
 use log::trace;
 
 const FILTER_EXEC_DEFAULT_SELECTIVITY: u8 = 20;
+
+/// Number of inner-loop iterations between cooperative yield checks
+/// when running with `--cfg datafusion_coop="per_stream"`. Mirrors the
+/// constant in `crate::coop` and matches Tokio's task budget.
+#[cfg(datafusion_coop = "per_stream")]
+const FILTER_YIELD_FREQUENCY: u8 = 128;
 
 /// FilterExec evaluates a boolean predicate against all input batches to determine which rows to
 /// include in its output batches.
@@ -303,7 +311,12 @@ impl FilterExec {
             output_partitioning,
             input.pipeline_behavior(),
             input.boundedness(),
-        ))
+        )
+        // FilterExec inserts cooperative yield points in its `poll_next` so that
+        // an all-rows-rejected batch loop cannot monopolise a Tokio worker.
+        // Marking the plan cooperative also signals to `EnsureCooperative` that
+        // it does not need to wrap this operator.
+        .with_scheduling_type(SchedulingType::Cooperative))
     }
 }
 
@@ -391,6 +404,8 @@ impl ExecutionPlan for FilterExec {
             input: self.input.execute(partition, context)?,
             baseline_metrics,
             projection: self.projection.clone(),
+            #[cfg(datafusion_coop = "per_stream")]
+            budget: FILTER_YIELD_FREQUENCY,
         }))
     }
 
@@ -626,6 +641,12 @@ struct FilterExecStream {
     baseline_metrics: BaselineMetrics,
     /// The projection indices of the columns in the input schema
     projection: Option<Vec<usize>>,
+    /// Cooperative-scheduling counter for `--cfg datafusion_coop="per_stream"`.
+    /// Decremented once per processed input batch; when it reaches zero the
+    /// stream yields to the runtime so the task remains cancellable even when
+    /// the predicate rejects every row.
+    #[cfg(datafusion_coop = "per_stream")]
+    budget: u8,
 }
 
 pub fn batch_filter(
@@ -677,6 +698,36 @@ impl Stream for FilterExecStream {
     ) -> Poll<Option<Self::Item>> {
         let poll;
         loop {
+            // Cooperative yield point: re-checked on every iteration so a
+            // predicate that rejects all rows in a batch cannot monopolise
+            // the worker. Mirrors `crate::coop::CooperativeStream::poll_next`
+            // for each of the three `cfg(datafusion_coop)` modes.
+            #[cfg(any(
+                datafusion_coop = "tokio",
+                not(any(
+                    datafusion_coop = "tokio_fallback",
+                    datafusion_coop = "per_stream"
+                ))
+            ))]
+            let coop = std::task::ready!(tokio::task::coop::poll_proceed(cx));
+
+            #[cfg(datafusion_coop = "tokio_fallback")]
+            {
+                if !tokio::task::coop::has_budget_remaining() {
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            }
+
+            #[cfg(datafusion_coop = "per_stream")]
+            {
+                if self.budget == 0 {
+                    self.budget = FILTER_YIELD_FREQUENCY;
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                }
+            }
+
             match ready!(self.input.poll_next_unpin(cx)) {
                 Some(Ok(batch)) => {
                     let timer = self.baseline_metrics.elapsed_compute().timer();
@@ -687,6 +738,35 @@ impl Stream for FilterExecStream {
                         &self.schema,
                     )?;
                     timer.done();
+
+                    // Account for the work that was just performed. This must
+                    // happen on both the empty-batch (continue) and non-empty
+                    // (return Ready) paths so that every predicate evaluation
+                    // counts toward the cooperative budget.
+                    #[cfg(any(
+                        datafusion_coop = "tokio",
+                        not(any(
+                            datafusion_coop = "tokio_fallback",
+                            datafusion_coop = "per_stream"
+                        ))
+                    ))]
+                    coop.made_progress();
+
+                    #[cfg(datafusion_coop = "tokio_fallback")]
+                    {
+                        // We've already done the work; consume one budget unit
+                        // by polling `consume_budget` once. Mirrors the pattern
+                        // in `crate::coop::CooperativeStream::poll_next`.
+                        let consume = tokio::task::coop::consume_budget();
+                        let consume_ref = std::pin::pin!(consume);
+                        let _ = consume_ref.poll(cx);
+                    }
+
+                    #[cfg(datafusion_coop = "per_stream")]
+                    {
+                        self.budget -= 1;
+                    }
+
                     // Skip entirely filtered batches
                     if filtered_batch.num_rows() == 0 {
                         continue;
@@ -695,6 +775,10 @@ impl Stream for FilterExecStream {
                     break;
                 }
                 value => {
+                    // Input ended or errored: do not record progress. In the
+                    // `tokio` mode the `coop` guard is dropped without
+                    // `made_progress`, restoring the budget unit reserved on
+                    // entry; this matches `CooperativeStream`'s behaviour.
                     poll = Poll::Ready(value);
                     break;
                 }


### PR DESCRIPTION
When a `FilterExec` predicate rejects every row in every batch, the inner `loop` in `FilterExecStream::poll_next` would spin without yielding to Tokio: each iteration consumed an input batch, produced an empty filtered batch, hit `continue`, and never exited the loop. On unbounded inputs this monopolised the worker and made the task uncancellable.

Insert a cooperative yield point at the top of each loop iteration and account for predicate work after each batch. Three variants gated on `cfg(datafusion_coop)` to mirror `crate::coop::CooperativeStream`:

- `tokio` (default): `poll_proceed(cx)` + `made_progress()` per batch.
- `tokio_fallback`: `has_budget_remaining()` check + drive `consume_budget()` once with the current cx after each batch.
- `per_stream`: local `u8` budget counter on `FilterExecStream`, reset to `FILTER_YIELD_FREQUENCY = 128` (matches Tokio's task budget) after each yield.

Mark `FilterExec` as `SchedulingType::Cooperative` so the `EnsureCooperative` optimizer rule does not wrap it.

Add a discriminating integration test
`filter_reject_all_batches_yields_without_cooperative_input` backed by a self-contained `NonCooperativeInfiniteExec` test fixture and a `query_yields_no_ensure_cooperative` helper that bypasses the optimizer rule. The test fails (10s timeout) without this change and passes with it, isolating the cooperative behavior to FilterExec itself.

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->