### PR TITLE
Fix pruning predicate for `LIKE` expressions with escape sequences (#22375)

### DIFF
--- a/datafusion/pruning/src/pruning_predicate.rs
+++ b/datafusion/pruning/src/pruning_predicate.rs
@@ -1641,8 +1641,10 @@ fn extract_string_literal(expr: &Arc<dyn PhysicalExpr>) -> Option<&str> {
 fn build_like_match(
     expr_builder: &mut PruningExpressionBuilder,
 ) -> Option<Arc<dyn PhysicalExpr>> {
-    // column LIKE literal => (min, max) LIKE literal split at % => min <= split literal && split literal <= max
+    // column LIKE literal => (min, max) LIKE literal split at unescaped % => min <= split literal && split literal <= max
     // column LIKE 'foo%' => min <= 'foo' && 'foo' <= max
+    // column LIKE 'foo\_%' => min <= 'foo_' && 'foo_' <= max (the _ is escaped)
+    // column LIKE 'foo\%%' => min <= 'foo%' && 'foo%' <= max (the % is escaped)
     // column LIKE '%foo' => min <= '' && '' <= max => true
     // column LIKE '%foo%' => min <= '' && '' <= max => true
     // column LIKE 'foo' => min <= 'foo' && 'foo' <= max
@@ -1655,24 +1657,25 @@ fn build_like_match(
     // check that the scalar is a string literal
     let s = extract_string_literal(scalar_expr)?;
     // ANSI SQL specifies two wildcards: % and _. % matches zero or more characters, _ matches exactly one character.
-    let first_wildcard_index = s.find(['%', '_']);
-    if first_wildcard_index == Some(0) {
-        // there's no filtering we could possibly do, return an error and have this be handled by the unhandled hook
+    let (decoded_prefix, rest) = split_constant_prefix(s);
+    let has_wildcard = !rest.is_empty();
+    if has_wildcard && decoded_prefix.is_empty() {
+        // there's no filtering we could possibly do, return None and have this be handled by the unhandled hook
         return None;
     }
-    let (lower_bound, upper_bound) = if let Some(wildcard_index) = first_wildcard_index {
-        let prefix = &s[..wildcard_index];
+    let (lower_bound, upper_bound) = if has_wildcard {
+        let incremented_prefix = increment_utf8(&decoded_prefix)?;
         let lower_bound_lit = Arc::new(phys_expr::Literal::new(ScalarValue::Utf8(Some(
-            prefix.to_string(),
+            decoded_prefix,
         ))));
         let upper_bound_lit = Arc::new(phys_expr::Literal::new(ScalarValue::Utf8(Some(
-            increment_utf8(prefix)?,
+            incremented_prefix,
         ))));
         (lower_bound_lit, upper_bound_lit)
     } else {
         // the like expression is a literal and can be converted into a comparison
         let bound = Arc::new(phys_expr::Literal::new(ScalarValue::Utf8(Some(
-            s.to_string(),
+            decoded_prefix,
         ))));
         (Arc::clone(&bound), bound)
     };
@@ -1753,19 +1756,20 @@ fn build_not_like_match(
 }
 
 /// Returns unescaped constant prefix of a LIKE pattern (possibly empty) and the remaining pattern (possibly empty)
-fn split_constant_prefix(pattern: &str) -> (&str, &str) {
-    let char_indices = pattern.char_indices().collect::<Vec<_>>();
-    for i in 0..char_indices.len() {
-        let (idx, char) = char_indices[i];
-        if char == '%' || char == '_' {
-            if i != 0 && char_indices[i - 1].1 == '\\' {
-                // ecsaped by `\`
-                continue;
-            }
-            return (&pattern[..idx], &pattern[idx..]);
+fn split_constant_prefix(pattern: &str) -> (String, &str) {
+    let mut prefix = String::with_capacity(pattern.len());
+    let mut iter = pattern.char_indices();
+    while let Some((idx, c)) = iter.next() {
+        match c {
+            '%' | '_' => return (prefix, &pattern[idx..]),
+            '\\' => match iter.next() {
+                Some((_, escaped)) => prefix.push(escaped),
+                None => prefix.push('\\'),
+            },
+            _ => prefix.push(c),
         }
     }
-    (pattern, "")
+    (prefix, "")
 }
 
 /// Increment a UTF8 string by one, returning `None` if it can't be incremented.
@@ -4392,6 +4396,174 @@ mod tests {
             // s1 ["AB", "A\u{10ffff}\u{10ffff}\u{10ffff}"]  ==> no rows can pass (not keep)
             false,
             // s1 ["A\u{10ffff}\u{10ffff}", "A\u{10ffff}\u{10ffff}"]  ==> no rows can pass (not keep)
+            false,
+        ];
+        prune_with_expr(expr, &schema, &statistics, expected_ret);
+    }
+
+    // `build_like_match()` must honor `\` escapes when scanning the pattern for
+    // wildcards.
+    #[test]
+    fn prune_utf8_like_escaped_chars() {
+        let schema = Arc::new(Schema::new(vec![Field::new("s1", DataType::Utf8, true)]));
+        let statistics = TestStatistics::new().with(
+            "s1",
+            ContainerStats::new_utf8(
+                vec![
+                    Some("foo_aaa"),
+                    Some(r#"foo\aaa"#),
+                    Some("foo"),
+                    Some("bar"),
+                    Some("foo%aaa"),
+                    Some("%foo_aaa"),
+                ], // min
+                vec![
+                    Some("foo_zzz"),
+                    Some(r#"foo\zzz"#),
+                    Some("foozzz"),
+                    Some("baz"),
+                    Some("foo%zzz"),
+                    Some("%foo_zzz"),
+                ], // max
+            ),
+        );
+
+        let expr = col("s1").like(lit(r#"foo\_%"#));
+        #[rustfmt::skip]
+        let expected_ret = &[
+            // s1 ["foo_aaa", "foo_zzz"] => every value starts with literal
+            // "foo_" and matches the pattern; must keep.
+            true,
+            // s1 ["foo\aaa", "foo\zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo", "foozzz"] => stats don't prove "foo_" is or isn't in
+            // range; must conservatively keep.
+            true,
+            // s1 ["bar", "baz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo%aaa", "foo%zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["%foo_aaa", "%foo_zzz"] => no rows can pass (not keep)
+            false,
+        ];
+        prune_with_expr(expr, &schema, &statistics, expected_ret);
+
+        let expr = col("s1").like(lit(r#"foo\\%"#));
+        #[rustfmt::skip]
+        let expected_ret = &[
+            // s1 ["foo_aaa", "foo_zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo\aaa", "foo\zzz"] => every value starts with literal
+            // "foo\" and matches the pattern; must keep.
+            true,
+            // s1 ["foo", "foozzz"] => stats don't prove "foo\" is or isn't in
+            // range; must conservatively keep.
+            true,
+            // s1 ["bar", "baz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo%aaa", "foo%zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["%foo_aaa", "%foo_zzz"] => no rows can pass (not keep)
+            false,
+        ];
+        prune_with_expr(expr, &schema, &statistics, expected_ret);
+
+        let expr = col("s1").like(lit(r#"foo\%%"#));
+        #[rustfmt::skip]
+        let expected_ret = &[
+            // s1 ["foo_aaa", "foo_zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo\aaa", "foo\zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo", "foozzz"] => range straddles "foo%"; must keep.
+            true,
+            // s1 ["bar", "baz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo%aaa", "foo%zzz"] => every value starts with literal
+            // "foo%" and matches the pattern; must keep.
+            true,
+            // s1 ["%foo_aaa", "%foo_zzz"] => no rows can pass (not keep)
+            false,
+        ];
+        prune_with_expr(expr, &schema, &statistics, expected_ret);
+
+        // No wildcard after escapes: pattern reduces to an equality check on
+        // the literal "foo_".
+        let expr = col("s1").like(lit(r#"foo\_"#));
+        #[rustfmt::skip]
+        let expected_ret = &[
+            // s1 ["foo_aaa", "foo_zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo\aaa", "foo\zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo", "foozzz"] => "foo_" is within the range; must keep.
+            true,
+            // s1 ["bar", "baz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo%aaa", "foo%zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["%foo_aaa", "%foo_zzz"] => no rows can pass (not keep)
+            false,
+        ];
+        prune_with_expr(expr, &schema, &statistics, expected_ret);
+
+        // Leading escaped `%`: prefix is "%foo" (non-empty), so the guard
+        // for "all wildcards" must NOT bail out here.
+        let expr = col("s1").like(lit(r#"\%foo%"#));
+        #[rustfmt::skip]
+        let expected_ret = &[
+            // s1 ["foo_aaa", "foo_zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo\aaa", "foo\zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo", "foozzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["bar", "baz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo%aaa", "foo%zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["%foo_aaa", "%foo_zzz"] => every value starts with literal
+            // "%foo" and matches the pattern; must keep.
+            true,
+        ];
+        prune_with_expr(expr, &schema, &statistics, expected_ret);
+
+        // Two escaped wildcards, no real wildcard: equality on "foo%_".
+        let expr = col("s1").like(lit(r#"foo\%\_"#));
+        #[rustfmt::skip]
+        let expected_ret = &[
+            // s1 ["foo_aaa", "foo_zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo\aaa", "foo\zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo", "foozzz"] => "foo%_" is within the range; must keep.
+            true,
+            // s1 ["bar", "baz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo%aaa", "foo%zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["%foo_aaa", "%foo_zzz"] => no rows can pass (not keep)
+            false,
+        ];
+        prune_with_expr(expr, &schema, &statistics, expected_ret);
+
+        // Escaped backslash followed by more literal chars before the
+        // wildcard: prefix is "foo\bar".
+        let expr = col("s1").like(lit(r#"foo\\bar%"#));
+        #[rustfmt::skip]
+        let expected_ret = &[
+            // s1 ["foo_aaa", "foo_zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo\aaa", "foo\zzz"] => range straddles "foo\bar"; must
+            // keep.
+            true,
+            // s1 ["foo", "foozzz"] => range straddles "foo\bar"; must keep.
+            true,
+            // s1 ["bar", "baz"] => no rows can pass (not keep)
+            false,
+            // s1 ["foo%aaa", "foo%zzz"] => no rows can pass (not keep)
+            false,
+            // s1 ["%foo_aaa", "%foo_zzz"] => no rows can pass (not keep)
             false,
         ];
         prune_with_expr(expr, &schema, &statistics, expected_ret);


### PR DESCRIPTION


## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123. -->

- Closes #22374.

## Rationale for this change

See #22374.

<!--
Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes. -->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This change includes a fix for the issue and a test that fails without this fix. The fix is straightforward: when splitting on the wildcard, we also unescape any escape sequences in the prefix.

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

I added a test that fails without this fix.

## Are there any user-facing changes?

No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->

# Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

 # Rationale for this change
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

# What changes are included in this PR?
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please add the `api change` label.
-->