### PR TITLE
slt: WindowAggExec untracked allocation (failing test)

### DIFF
--- a/datafusion/sqllogictest/test_files/memory_accounting_demo.slt
+++ b/datafusion/sqllogictest/test_files/memory_accounting_demo.slt
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Failing test that exposes an untracked allocation in WindowAggExec.
+#
+# WindowAggStream (physical-plan/src/windows/window_agg_exec.rs:429) pushes
+# every input batch into a Vec<RecordBatch> with no MemoryReservation
+# tracking; concat_batches then materializes a doubled copy. The
+# operator's footprint never reaches DataFusion's MemoryPool, so DF
+# happily runs this query under a 100 MB pool while the heap grows to
+# ~1 GB.
+#
+# Configuration is intentionally non-engineered: default 10% headroom
+# from accounting_pool.rs::HEADROOM_FACTOR. max(msg) OVER () references
+# msg so the optimizer cannot elide the carry, forcing Window to buffer
+# the wide payload.
+#
+# `statement ok` is the assertion DataFusion *should* be able to honor.
+# Today it can't — the allocator bank catches the overdraft and the
+# statement fails. Fix the WindowAgg accounting gap, this test goes
+# green.
+
+statement ok
+SET datafusion.runtime.memory_limit = '100M'
+
+statement ok
+SELECT msg, max(msg) OVER () AS max_msg
+FROM (
+    SELECT 'payload-' || cast(i AS varchar) || repeat('q', 1000) AS msg
+    FROM generate_series(1, 500000) AS t(i)
+)
+LIMIT 5
+
+statement ok
+RESET datafusion.catalog.create_default_catalog_and_schema


### PR DESCRIPTION
## Summary

Adds a failing SLT that exposes a real DataFusion accounting bug via the framework in the parent PR.

`WindowAggStream` holds references to every input batch for the whole stream without telling `MemoryPool`. The bytes were allocated upstream — Window doesn't double them — but Window is the reason they aren't dropped. Because the pool never sees that retention, spill triggers and backpressure don't fire, and upstream operators keep allocating into a budget they think is free. The framework's allocator-level bank notices on the very next upstream alloc.

## The offending lines

**Retention without accounting** — `datafusion/physical-plan/src/windows/window_agg_exec.rs:429`
```rust
loop {
    return Poll::Ready(Some(match ready!(self.input.poll_next_unpin(cx)) {
        Some(Ok(batch)) => {
            self.batches.push(batch);   // ← no reservation.try_grow(batch_size)
            continue;
        }
        // ...
```
[permalink](https://github.com/coralogix/arrow-datafusion/blob/8c14bae07386e160242ef6c457f15d5bf8005dc4/datafusion/physical-plan/src/windows/window_agg_exec.rs#L429)

The push itself is just an `Arc::clone` — the bytes are upstream's. But this is where they stop being eligible for drop. With 500 K rows × ~1 KB payload, that's ~500 MB of Arrow buffers kept alive while `MemoryPool::reserved()` stays near zero.

**End-of-stream rebuild** — same file, line 362:
```rust
let batch = concat_batches(&self.input.schema(), &self.batches)?;
```
[permalink](https://github.com/coralogix/arrow-datafusion/blob/8c14bae07386e160242ef6c457f15d5bf8005dc4/datafusion/physical-plan/src/windows/window_agg_exec.rs#L362)

`concat_batches` allocates fresh buffers for primitive arrays; for `Utf8View` it can reuse the data buffers but still rebuilds the view list and null bitmap. Also unaccounted.

`WindowAggStream` has no reservation field — `grep -n "reservation\|try_grow\|MemoryConsumer\|MemoryReservation" window_agg_exec.rs` returns nothing.

## Why this matters in practice

A query with a single global window over wide rows under a tight pool runs to ~10× the declared budget on the heap. `MemoryPool::reserved()` will report a small number throughout because nothing in this operator ever calls `try_grow`. Operators downstream of Window that *do* spill will never decide to, because the pool looks empty. Eventually a real allocation pushes us over the kernel's tolerance and the process dies — there's no `ResourcesExhausted` error to catch.

## Reproducer

Configuration is intentionally non-engineered: default 10 % headroom from `accounting_pool.rs::HEADROOM_FACTOR`, 100 MB pool. `max(msg) OVER ()` references the wide payload so the optimizer can't elide the carry through `WindowAggExec`.

```
External error: 1 errors in file datafusion/sqllogictest/test_files/memory_accounting_demo.slt

1. statement failed: Other Error: allocator overdraft: account balance at panic = -317042 bytes
[SQL] SELECT msg, max(msg) OVER () AS max_msg
FROM (
    SELECT 'payload-' || cast(i AS varchar) || repeat('q', 1000) AS msg
    FROM generate_series(1, 500000) AS t(i)
)
LIMIT 5
```

## Stack trace at the firing allocation

```
thread 'slt-file-1' panicked at datafusion/sqllogictest/src/accounting.rs:235:9:
   1: std::panic::panic_any
   2: datafusion_sqllogictest::accounting::track::{{closure}}        ← bank crossed zero
   4: <AccountingAllocator as GlobalAlloc>::alloc
   6: <RawVecInner>::finish_grow
   9: GenericByteViewBuilder::try_append_value
  10: datafusion_physical_expr::expressions::binary::kernels::concat_elements_utf8view
  11: datafusion_physical_expr::expressions::binary::concat_elements
  12: BinaryExpr::evaluate_with_resolved_args                        ← payload concat in upstream projection
  33: ProjectionStream::batch_project
```

The crashing alloc is innocent on its own — a string-concat in the projection feeding Window. It's just the alloc that happens after Window has silently consumed the budget by retaining every prior batch.

## Test plan

- [ ] `cargo test --features memory-accounting -p datafusion-sqllogictest --test sqllogictests -- memory_accounting_demo --default-pool-size-mb 100` exits non-zero with the message above.
