### PR TITLE
Appease fork CI: rustfmt + expect(deprecated) in topk_repartition

### DIFF
--- a/datafusion/physical-optimizer/src/topk_repartition.rs
+++ b/datafusion/physical-optimizer/src/topk_repartition.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// CoalesceBatchesExec is deprecated in DF 53 but planners may still insert it
+// between SortExec and RepartitionExec, so this rule keeps matching it.
+#![expect(deprecated)]
+
 //! Push TopK (Sort with fetch) past Hash Repartition
 //!
 //! When a `SortExec` with a fetch limit (TopK) sits above a

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -77,8 +77,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::utils::memory::estimate_memory_size;
 use datafusion_common::{
     DataFusionError, JoinSide, JoinType, NullEquality, Result, assert_or_internal_err,
-    internal_err,
-    plan_err, project_schema,
+    internal_err, plan_err, project_schema,
 };
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};


### PR DESCRIPTION
Fixes the two CI failures on the freshly-rebased `v53` branch (CX-47359):

- rustfmt the merged import block in `hash_join/exec.rs` (fmt check)
- `CoalesceBatchesExec` is deprecated in DF 53; `topk_repartition` intentionally still matches it, so `expect(deprecated)` module-wide (clippy `-D warnings`)

Build/test jobs were already green on the branch: amd64 tests, macOS tests, and benchmark verification all passed in [run 30089392875](https://github.com/coralogix/arrow-datafusion/actions/runs/30089392875).

🤖 Generated with [Claude Code](https://claude.com/claude-code)