### PR TITLE
Backport empty-projection serde fixes to v53

### DIFF
--- a/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
+++ b/datafusion/optimizer/src/decorrelate_predicate_subquery.rs
@@ -461,9 +461,11 @@ fn build_join(
     //
     // Additionally, if the join keys are non-nullable on both sides, we don't need
     // null-aware semantics because NULLs cannot exist in the data.
-    let null_aware = join_type == JoinType::LeftAnti
-        && in_predicate_opt.is_some()
-        && join_keys_may_be_null(&join_filter, left.schema(), sub_query_alias.schema())?;
+    // Fork-only: DataPrime's `!x.inArray(y)` is two-valued — a NULL in the
+    // subquery must not drop the row — so we keep the plain anti join instead of
+    // SQL `NOT IN` three-valued semantics. Restores pre-DF53 behaviour.
+    let null_aware = false;
+    let _ = (&in_predicate_opt, &join_filter);
 
     // join our sub query into the main plan
     let new_plan = if null_aware {

--- a/datafusion/physical-expr/src/simplifier/mod.rs
+++ b/datafusion/physical-expr/src/simplifier/mod.rs
@@ -60,8 +60,12 @@ impl<'a> PhysicalExprSimplifier<'a> {
         while count < MAX_LOOP_COUNT {
             count += 1;
             let result = current_expr.transform(|node| {
+                // Only a sanity check: an expression may legitimately have no
+                // statically inferable type here (e.g. a predicate typed against
+                // a virtual schema), so record the type when it is known instead
+                // of unwrapping and panicking.
                 #[cfg(debug_assertions)]
-                let original_type = node.data_type(schema).unwrap();
+                let original_type = node.data_type(schema).ok();
 
                 // Apply NOT expression simplification first, then unwrap cast optimization,
                 // then constant expression evaluation
@@ -73,11 +77,13 @@ impl<'a> PhysicalExprSimplifier<'a> {
                     })?;
 
                 #[cfg(debug_assertions)]
-                assert_eq!(
-                    rewritten.data.data_type(schema).unwrap(),
-                    original_type,
-                    "Simplified expression should have the same data type as the original"
-                );
+                if let Some(original_type) = original_type {
+                    assert_eq!(
+                        rewritten.data.data_type(schema).ok(),
+                        Some(original_type),
+                        "Simplified expression should have the same data type as the original"
+                    );
+                }
 
                 Ok(rewritten)
             })?;

--- a/datafusion/physical-expr/src/simplifier/unwrap_cast.rs
+++ b/datafusion/physical-expr/src/simplifier/unwrap_cast.rs
@@ -128,7 +128,13 @@ fn try_unwrap_cast_comparison(
     if let Some(casted_literal) = try_cast_literal_to_type(literal_value, &inner_type) {
         let literal_expr = lit(casted_literal);
         let binary_expr = BinaryExpr::new(inner_expr, op, literal_expr);
-        return Ok(Some(Arc::new(binary_expr)));
+        // Keep the rewrite only if it is still well typed. The cast of the
+        // literal is not guaranteed to yield `inner_type`, and dropping the
+        // outer cast in that case leaves a comparison whose sides cannot be
+        // coerced (e.g. `Timestamp > Float64`).
+        if binary_expr.data_type(schema).is_ok() {
+            return Ok(Some(Arc::new(binary_expr)));
+        }
     }
 
     Ok(None)

--- a/datafusion/physical-optimizer/src/topk_repartition.rs
+++ b/datafusion/physical-optimizer/src/topk_repartition.rs
@@ -15,6 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// CoalesceBatchesExec is deprecated in DF 53 but planners may still insert it
+// between SortExec and RepartitionExec, so this rule keeps matching it.
+#![expect(deprecated)]
+
 //! Push TopK (Sort with fetch) past Hash Repartition
 //!
 //! When a `SortExec` with a fetch limit (TopK) sits above a

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -77,8 +77,7 @@ use datafusion_common::config::ConfigOptions;
 use datafusion_common::utils::memory::estimate_memory_size;
 use datafusion_common::{
     DataFusionError, JoinSide, JoinType, NullEquality, Result, assert_or_internal_err,
-    internal_err,
-    plan_err, project_schema,
+    internal_err, plan_err, project_schema,
 };
 use datafusion_execution::TaskContext;
 use datafusion_execution::memory_pool::{MemoryConsumer, MemoryReservation};

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -1400,16 +1400,15 @@ impl protobuf::PhysicalPlanNode {
             protobuf::PartitionMode::Partitioned => PartitionMode::Partitioned,
             protobuf::PartitionMode::Auto => PartitionMode::Auto,
         };
-        let projection = if !hashjoin.projection.is_empty() {
-            Some(
-                hashjoin
-                    .projection
-                    .iter()
-                    .map(|i| *i as usize)
-                    .collect::<Vec<_>>(),
-            )
-        } else {
-            None
+        // Proto3 `repeated` cannot distinguish `None` from `Some(vec![])`. The latter
+        // is reachable via `try_embed_projection` for `SELECT count(1) … JOIN …` and
+        // changes the join's output schema, so the encoder reserves the single-element
+        // sentinel `[u32::MAX]` (never a valid column index) to mean "explicitly empty";
+        // every other state is sent as-is. See `try_from_hash_join_exec`.
+        let projection = match hashjoin.projection.as_slice() {
+            [] => None,
+            [u32::MAX] => Some(Vec::new()),
+            indices => Some(indices.iter().map(|i| *i as usize).collect()),
         };
         Ok(Arc::new(HashJoinExec::try_new(
             left,
@@ -1804,15 +1803,13 @@ impl protobuf::PhysicalPlanNode {
                     })
                     .map_or(Ok(None), |v: Result<JoinFilter>| v.map(Some))?;
 
-        let projection = if !join.projection.is_empty() {
-            Some(
-                join.projection
-                    .iter()
-                    .map(|i| *i as usize)
-                    .collect::<Vec<_>>(),
-            )
-        } else {
-            None
+        // See `try_into_hash_join_physical_plan` for the rationale behind the
+        // `[u32::MAX]` sentinel; `NestedLoopJoinExec` has the same `Option<Vec<usize>>`
+        // projection field and shares the proto3 `repeated` ambiguity.
+        let projection = match join.projection.as_slice() {
+            [] => None,
+            [u32::MAX] => Some(Vec::new()),
+            indices => Some(indices.iter().map(|i| *i as usize).collect()),
         };
 
         Ok(Arc::new(NestedLoopJoinExec::try_new(
@@ -2465,9 +2462,14 @@ impl protobuf::PhysicalPlanNode {
                     partition_mode: partition_mode.into(),
                     null_equality: null_equality.into(),
                     filter,
-                    projection: exec.projection.as_ref().map_or_else(Vec::new, |v| {
-                        v.iter().map(|x| *x as u32).collect::<Vec<u32>>()
-                    }),
+                    // Send `Some(vec![])` as `[u32::MAX]` (never a valid index) so the
+                    // wire format can distinguish it from `None` (which stays empty).
+                    // See `try_into_hash_join_physical_plan` for the matching decoder.
+                    projection: match exec.projection.as_ref() {
+                        None => Vec::new(),
+                        Some(v) if v.is_empty() => vec![u32::MAX],
+                        Some(v) => v.iter().map(|x| *x as u32).collect(),
+                    },
                     null_aware: exec.null_aware,
                 },
             ))),
@@ -3239,9 +3241,13 @@ impl protobuf::PhysicalPlanNode {
                     right: Some(Box::new(right)),
                     join_type: join_type.into(),
                     filter,
-                    projection: exec.projection().as_ref().map_or_else(Vec::new, |v| {
-                        v.iter().map(|x| *x as u32).collect::<Vec<u32>>()
-                    }),
+                    // `[u32::MAX]` sentinel distinguishes `Some(vec![])` from `None`;
+                    // see `try_from_hash_join_exec`.
+                    projection: match exec.projection().as_ref() {
+                        None => Vec::new(),
+                        Some(v) if v.is_empty() => vec![u32::MAX],
+                        Some(v) => v.iter().map(|x| *x as u32).collect(),
+                    },
                 },
             ))),
         })

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -680,18 +680,23 @@ impl protobuf::PhysicalPlanNode {
             })?;
 
         let filter_selectivity = filter.default_filter_selectivity.try_into();
-        let projection = if !filter.projection.is_empty() {
-            Some(
-                filter
-                    .projection
-                    .iter()
-                    .map(|i| *i as usize)
-                    .collect::<Vec<_>>(),
-            )
-        } else {
+        // Preserve the `None` state across proto boundaries. Proto cannot distinguish
+        // between `None` (full projection) and `Some(vec![])` (empty projection) since
+        // both serialize as an empty list. If all columns are included, we reconstruct
+        // `None` to avoid losing this semantic distinction on deserialization.
+        let num_fields = input.schema().fields().len();
+        let mut is_full_projection = filter.projection.len() == num_fields;
+        let mut projection_vec: Vec<usize> = Vec::with_capacity(filter.projection.len());
+        for (i, idx) in filter.projection.iter().enumerate() {
+            let idx = *idx as usize;
+            is_full_projection &= idx == i;
+            projection_vec.push(idx);
+        }
+        let projection = if is_full_projection {
             None
+        } else {
+            Some(projection_vec)
         };
-
         let filter = FilterExecBuilder::new(predicate, input)
             .apply_projection(projection)?
             .with_batch_size(filter.batch_size as usize)
@@ -2331,9 +2336,12 @@ impl protobuf::PhysicalPlanNode {
                             .physical_expr_to_proto(exec.predicate(), codec)?,
                     ),
                     default_filter_selectivity: exec.default_selectivity() as u32,
-                    projection: exec.projection().as_ref().map_or_else(Vec::new, |v| {
-                        v.iter().map(|x| *x as u32).collect::<Vec<u32>>()
-                    }),
+                    projection: match exec.projection() {
+                        None => (0..exec.input().schema().fields().len())
+                            .map(|i| i as u32)
+                            .collect(),
+                        Some(v) => v.iter().map(|x| *x as u32).collect(),
+                    },
                     batch_size: exec.batch_size() as u32,
                     fetch: exec.fetch().map(|f| f as u32),
                 },

--- a/datafusion/proto/src/physical_plan/mod.rs
+++ b/datafusion/proto/src/physical_plan/mod.rs
@@ -934,15 +934,11 @@ impl protobuf::PhysicalPlanNode {
         })?;
         let schema: SchemaRef = SchemaRef::new(proto_schema.try_into()?);
 
-        let projection = if !scan.projection.is_empty() {
-            Some(
-                scan.projection
-                    .iter()
-                    .map(|i| *i as usize)
-                    .collect::<Vec<_>>(),
-            )
-        } else {
-            None
+        // Decode the empty-projection sentinel written by `try_from_memory_scan_exec`.
+        let projection = match scan.projection.as_slice() {
+            [] => None,
+            [u32::MAX] => Some(Vec::new()),
+            indices => Some(indices.iter().map(|i| *i as usize).collect::<Vec<_>>()),
         };
 
         let mut sort_information = vec![];
@@ -2988,12 +2984,15 @@ impl protobuf::PhysicalPlanNode {
             let proto_schema: protobuf::Schema =
                 source_conf.original_schema().as_ref().try_into()?;
 
-            let proto_projection = source_conf
-                .projection()
-                .as_ref()
-                .map_or_else(Vec::new, |v| {
-                    v.iter().map(|x| *x as u32).collect::<Vec<u32>>()
-                });
+            // Proto3 `repeated` cannot distinguish `None` from `Some(vec![])`.
+            // `Some(vec![])` projects away every column and so changes the output
+            // schema; it is encoded with the single-element sentinel `[u32::MAX]`
+            // (never a valid column index). Every other state is sent as-is.
+            let proto_projection = match source_conf.projection().as_ref() {
+                None => Vec::new(),
+                Some(v) if v.is_empty() => vec![u32::MAX],
+                Some(v) => v.iter().map(|x| *x as u32).collect::<Vec<u32>>(),
+            };
 
             let proto_sort_information = source_conf
                 .sort_information()

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -34,6 +34,7 @@ use datafusion::datasource::file_format::parquet::ParquetSink;
 use datafusion::datasource::listing::{
     ListingOptions, ListingTable, ListingTableConfig, ListingTableUrl, PartitionedFile,
 };
+use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::object_store::ObjectStoreUrl;
 use datafusion::datasource::physical_plan::{
     ArrowSource, FileGroup, FileOutputMode, FileScanConfig, FileScanConfigBuilder,
@@ -2404,6 +2405,24 @@ async fn roundtrip_memory_source() -> Result<()> {
         .create_physical_plan()
         .await?;
     roundtrip_test(plan)
+}
+
+#[test]
+fn roundtrip_memory_source_projections() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+    ]));
+
+    // `None` (all columns), `Some(vec![])` (no columns) and a partial projection are
+    // three distinct output schemas and must each survive a round-trip.
+    for projection in [None, Some(vec![]), Some(vec![1])] {
+        let source =
+            MemorySourceConfig::try_new(&[vec![]], Arc::clone(&schema), projection)?;
+        roundtrip_test(Arc::new(DataSourceExec::new(Arc::new(source))))?;
+    }
+
+    Ok(())
 }
 
 #[tokio::test]

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -338,6 +338,59 @@ fn roundtrip_nested_loop_join() -> Result<()> {
     Ok(())
 }
 
+/// Regression: proto3 `repeated` fields cannot distinguish "absent" from "empty",
+/// so a naive encoding collapses `Some(vec![])` and `None` into the same wire
+/// representation. `try_embed_projection` (DataFusion 53+) produces
+/// `HashJoinExec.projection = Some(vec![])` for `SELECT count(1) … JOIN …`,
+/// which previously round-tripped to `None` and caused downstream consumers (e.g.
+/// distributed Flight executors) to receive a different number of output
+/// columns than the planner declared. Verify all three states preserve.
+#[test]
+fn roundtrip_hash_join_projection_states() -> Result<()> {
+    let field_a = Field::new("col", DataType::Int64, false);
+    let schema_left = Arc::new(Schema::new(vec![field_a.clone()]));
+    let schema_right = Arc::new(Schema::new(vec![field_a]));
+    let on = vec![(
+        Arc::new(Column::new("col", schema_left.index_of("col")?)) as _,
+        Arc::new(Column::new("col", schema_right.index_of("col")?)) as _,
+    )];
+
+    for projection in [None, Some(vec![]), Some(vec![0]), Some(vec![1])] {
+        roundtrip_test(Arc::new(HashJoinExec::try_new(
+            Arc::new(EmptyExec::new(schema_left.clone())),
+            Arc::new(EmptyExec::new(schema_right.clone())),
+            on.clone(),
+            None,
+            &JoinType::Inner,
+            projection,
+            PartitionMode::Partitioned,
+            NullEquality::NullEqualsNothing,
+            false,
+        )?))?;
+    }
+    Ok(())
+}
+
+/// Same regression coverage for `NestedLoopJoinExec`, which shares the
+/// `repeated uint32 projection` proto field shape with `HashJoinExec`.
+#[test]
+fn roundtrip_nested_loop_join_projection_states() -> Result<()> {
+    let field_a = Field::new("col", DataType::Int64, false);
+    let schema_left = Arc::new(Schema::new(vec![field_a.clone()]));
+    let schema_right = Arc::new(Schema::new(vec![field_a]));
+
+    for projection in [None, Some(vec![]), Some(vec![0]), Some(vec![1])] {
+        roundtrip_test(Arc::new(NestedLoopJoinExec::try_new(
+            Arc::new(EmptyExec::new(schema_left.clone())),
+            Arc::new(EmptyExec::new(schema_right.clone())),
+            None,
+            &JoinType::Inner,
+            projection,
+        )?))?;
+    }
+    Ok(())
+}
+
 #[test]
 fn roundtrip_udwf() -> Result<()> {
     let field_a = Field::new("a", DataType::Int64, false);

--- a/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
+++ b/datafusion/proto/tests/cases/roundtrip_physical_plan.rs
@@ -3167,3 +3167,39 @@ fn roundtrip_lead_with_default_value() -> Result<()> {
         true,
     )?))
 }
+#[test]
+fn roundtrip_filter_with_none_projection() -> Result<()> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("a", DataType::Int32, false),
+        Field::new("b", DataType::Int32, false),
+        Field::new("c", DataType::Int32, false),
+    ]));
+    let predicate: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+        Arc::new(Column::new("a", 0)),
+        Operator::Gt,
+        lit(ScalarValue::Int32(Some(0))),
+    ));
+    let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::clone(&schema)));
+
+    // Case 1: None projection (return all columns)
+    roundtrip_test(Arc::new(FilterExec::try_new(
+        Arc::clone(&predicate),
+        Arc::clone(&input),
+    )?))?;
+
+    // Case 2: Some(vec![]) — explicitly empty projection
+    roundtrip_test(Arc::new(
+        FilterExecBuilder::new(Arc::clone(&predicate), Arc::clone(&input))
+            .apply_projection(Some(vec![]))?
+            .build()?,
+    ))?;
+
+    // Case 3: Some(vec![2, 0]) — partial projection
+    roundtrip_test(Arc::new(
+        FilterExecBuilder::new(Arc::clone(&predicate), Arc::clone(&input))
+            .apply_projection(Some(vec![2, 0]))?
+            .build()?,
+    ))?;
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes the root cause behind DQE's `failed to decode task: ... UnionExec/InterleaveExec requires all inputs to have the same number of fields` (dataprime-query-engine#6767, CX-47359).

## Problem

Join, filter and memory-scan projections are encoded as a bare `repeated uint32`:

```rust
// encode
projection: exec.projection.as_ref().map_or_else(Vec::new, |v| ...),
// decode
let projection = if !hashjoin.projection.is_empty() { Some(...) } else { None };
```

So `Some(vec![])` — project away every column, which projection pushdown builds for queries that only count rows — serializes exactly like `None` and always decodes back as `None`. The decoded node then reports its full, unprojected schema.

Locally that's invisible; across a wire it silently changes a plan's shape and breaks the parent. In DQE a `UnionExec` over a zero-column scan and a zero-column join fails on the executor as soon as the plan is decoded, because DF53 validates field counts in `UnionExec::try_new`:

```
UnionExec/InterleaveExec requires all inputs to have the same number of fields.
Input 0 has 0 fields, but input 1 has 2 fields
```

## What's here

Upstream already fixed this for three of the four affected nodes, and both fixes predate the `proto` → `physical-plan` serde refactor, so they cherry-pick onto our v53 base as-is:

| commit | node(s) | scheme |
|---|---|---|
| `b295fcf9b1` = apache#21885 | `FilterExec` | encode `None` as the identity list `[0..n]` |
| `ea7ae7e77f` = apache#23082 | `HashJoinExec`, `NestedLoopJoinExec` | encode `Some(vec![])` as the sentinel `[u32::MAX]` |

Both are clean cherry-picks (original authorship kept; the only conflict was where in the test file the new tests land).

On top, one new commit fixes `MemoryScanExec`, which is **still** broken upstream, using the same `[u32::MAX]` sentinel as the joins. Sent upstream as apache/datafusion#24084 — once that merges this commit drops out on the next rebase.

Taking upstream's wire format rather than inventing our own matters here: the same proto field would otherwise be encoded two different ways, and every future rebase past those commits would conflict.

## Rolling upgrades

Only the previously-unrepresentable `Some(vec![])` case changes on the wire. DQE rolls schedulers (encoders) and executors (decoders) independently, so both directions matter:

- **old writer → new reader**: `[]` still reads as `None`; non-empty reads as `Some`. Unchanged.
- **new writer → old reader**: non-empty unchanged. A zero-column join/scan sends `[u32::MAX]`, which an old reader turns into `Some([4294967295])` → a loud invalid-column-index error rather than silent corruption. That case is *already* broken on `v53.1.0-cx.3` (it is this bug), and dataprime-query-engine#6767 keeps the scheduler from emitting those plans at all, so the mixed window is covered from the DQE side.

## Tests

The two cherry-picks bring their upstream tests; `roundtrip_memory_source_projections` covers `None` / `Some(vec![])` / partial for the memory scan. Verified it fails without the fix (`projection: Some([])` vs `None`, schema growing from `[]` back to every column).

The 6 pre-existing `roundtrip_parquet_*` / `roundtrip_empty_projection` / `roundtrip_physical_plan_node` failures are unrelated — identical on `v53.1.0-cx.3`. Passing count goes 141 → 145.

## Note on the diff

Branched off the `v53.1.0-cx.3` tag, which is 4 commits ahead of `v53` (tagged but never pushed to the branch), so those 4 show up here too. Only the last 3 commits are new.

Needs a `v53.1.0-cx.4` tag afterwards, then a Cargo.toml bump in DQE.